### PR TITLE
帝国圣卫军盾牌投掷技能技改

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -1,4 +1,4 @@
-# This file is a part of rAthena.
+﻿# This file is a part of rAthena.
 #   Copyright(C) 2021 rAthena Development Team
 #   https://rathena.org - https://github.com/rathena
 #
@@ -37065,10 +37065,13 @@ Body:
     MaxLevel: 5
     Type: Weapon
     TargetType: Attack
+    DamageFlags:
+      Splash: true
     Range: 9
     Hit: Multi_Hit
     HitCount: -7
     Element: Weapon
+    SplashArea: 3
     GiveAp: 3
     CastCancel: true
     CastTime: 500

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -5850,14 +5850,14 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio += skillratio * i / 100;
 			break;
 		case IG_SHIELD_SHOOTING:
-			skillratio += -100 + 1400 + 2100 * skill_lv + 5 * sstatus->pow;
-			skillratio += skill_lv * 15 * pc_checkskill( sd, IG_SHIELD_MASTERY );
+			skillratio += -100 + 750 + 2850 * skill_lv + 7 * sstatus->pow;
+			skillratio += skill_lv * 50 * pc_checkskill( sd, IG_SHIELD_MASTERY );
 			if (sd) { // Damage affected by the shield's weight and refine. Need official formula. [Rytech]
 				short index = sd->equip_index[EQI_HAND_L];
 
 				if (index >= 0 && sd->inventory_data[index] && sd->inventory_data[index]->type == IT_ARMOR) {
 					skillratio += (sd->inventory_data[index]->weight * 7 / 6) / 10;
-					skillratio += sd->inventory.u.items_inventory[index].refine * 4;
+					skillratio += sd->inventory.u.items_inventory[index].refine * 25;
 				}
 			}
 			RE_LVL_DMOD(100);


### PR DESCRIPTION
以LV5为基准：
变更为对目标及其周围7*7范围内的目标造成远距离物理伤害
依[盾牌精熟]习得Lv的加成值从75增加到250
技能基础倍率从11900%增加至14900%
pow权重从5增加至7
盾牌精炼值的权重从4增加至25
