### PR TITLE
20221221技改

### DIFF
--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -35126,6 +35126,7 @@ Body:
     TargetType: Attack
     DamageFlags:
       Splash: true
+      Critical: true
     Range: 2
     Hit: Multi_Hit
     HitCount: 2
@@ -35138,19 +35139,19 @@ Body:
       - Level: 3
         Area: 1
       - Level: 4
-        Area: 2
+        Area: 1
       - Level: 5
         Area: 2
       - Level: 6
         Area: 2
       - Level: 7
-        Area: 3
+        Area: 2
       - Level: 8
-        Area: 3
+        Area: 2
       - Level: 9
         Area: 3
       - Level: 10
-        Area: 4
+        Area: 3
     CastCancel: true
     AfterCastActDelay: 250
     Cooldown: 700
@@ -35187,6 +35188,7 @@ Body:
     TargetType: Attack
     DamageFlags:
       Splash: true
+      Critical: true
     Range: 2
     Hit: Multi_Hit
     HitCount: 2
@@ -35199,19 +35201,19 @@ Body:
       - Level: 3
         Area: 1
       - Level: 4
-        Area: 2
+        Area: 1
       - Level: 5
         Area: 2
       - Level: 6
         Area: 2
       - Level: 7
-        Area: 3
+        Area: 2
       - Level: 8
-        Area: 3
+        Area: 2
       - Level: 9
         Area: 3
       - Level: 10
-        Area: 4
+        Area: 3
     Requires:
       SpCost: 1
   - Id: 5210
@@ -35264,15 +35266,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 36
+          Amount: 23
         - Level: 2
-          Amount: 44
+          Amount: 31
         - Level: 3
-          Amount: 52
+          Amount: 39
         - Level: 4
-          Amount: 60
+          Amount: 47
         - Level: 5
-          Amount: 68
+          Amount: 55
       Weapon:
         2hSword: true
         2hSpear: true
@@ -35337,19 +35339,19 @@ Body:
     GiveAp: 2
     CastCancel: true
     AfterCastActDelay: 500
-    Cooldown: 300
+    Cooldown: 350
     Requires:
       SpCost:
         - Level: 1
-          Amount: 40
+          Amount: 35
         - Level: 2
-          Amount: 45
+          Amount: 40
         - Level: 3
-          Amount: 50
+          Amount: 45
         - Level: 4
-          Amount: 55
+          Amount: 50
         - Level: 5
-          Amount: 60
+          Amount: 55
       Weapon:
         2hSword: true
         2hAxe: true
@@ -35420,20 +35422,20 @@ Body:
     CastTime: 4000
     AfterCastActDelay: 500
     Duration2: 900000
-    Cooldown: 2000
+    Cooldown: 2500
     FixedCastTime: 1500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 108
+          Amount: 162
         - Level: 2
-          Amount: 114
+          Amount: 168
         - Level: 3
-          Amount: 120
+          Amount: 174
         - Level: 4
-          Amount: 126
+          Amount: 180
         - Level: 5
-          Amount: 132
+          Amount: 186
     Status: Climax_Des_Hu
   - Id: 5216
     Name: AG_RAIN_OF_CRYSTAL
@@ -35453,28 +35455,28 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 84
+          Amount: 109
         - Level: 2
-          Amount: 88
+          Amount: 113
         - Level: 3
-          Amount: 92
+          Amount: 117
         - Level: 4
-          Amount: 96
+          Amount: 121
         - Level: 5
-          Amount: 100
+          Amount: 125
     Unit:
       Id: Rain_Of_Crystal
       Range:
         - Level: 1
-          Size: 6
+          Size: 4
         - Level: 2
-          Size: 7
+          Size: 4
         - Level: 3
-          Size: 8
+          Size: 5
         - Level: 4
-          Size: 9
+          Size: 5
         - Level: 5
-          Size: 10
+          Size: 6
       Interval: 500
       Target: Enemy
       Flag:
@@ -35844,15 +35846,15 @@ Body:
     Element: Water
     SplashArea:
       - Level: 1
-        Area: 3
+        Area: 4
       - Level: 2
         Area: 4
       - Level: 3
         Area: 5
       - Level: 4
-        Area: 6
+        Area: 5
       - Level: 5
-        Area: 7
+        Area: 6
     CastCancel: true
     CastTime: 4000
     AfterCastActDelay: 500
@@ -35862,15 +35864,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 100
+          Amount: 120
         - Level: 2
-          Amount: 108
+          Amount: 128
         - Level: 3
-          Amount: 116
+          Amount: 136
         - Level: 4
-          Amount: 124
+          Amount: 144
         - Level: 5
-          Amount: 132
+          Amount: 152
     Status: Climax_CryImp
   - Id: 5226
     Name: AG_CRYSTAL_IMPACT_ATK
@@ -36124,15 +36126,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 68
+          Amount: 64
         - Level: 2
-          Amount: 74
+          Amount: 70
         - Level: 3
-          Amount: 80
+          Amount: 76
         - Level: 4
-          Amount: 86
+          Amount: 82
         - Level: 5
-          Amount: 92
+          Amount: 88
   - Id: 5234
     Name: AG_STORM_CANNON
     Description: Storm Cannon
@@ -36164,15 +36166,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 78
+          Amount: 72
         - Level: 2
-          Amount: 82
+          Amount: 76
         - Level: 3
-          Amount: 86
+          Amount: 80
         - Level: 4
-          Amount: 90
+          Amount: 84
         - Level: 5
-          Amount: 94
+          Amount: 88
   - Id: 5235
     Name: AG_CRIMSON_ARROW
     Description: Crimson Arrow
@@ -36204,15 +36206,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 86
+          Amount: 82
         - Level: 2
-          Amount: 88
+          Amount: 84
         - Level: 3
-          Amount: 90
+          Amount: 86
         - Level: 4
-          Amount: 92
+          Amount: 88
         - Level: 5
-          Amount: 94
+          Amount: 90
   - Id: 5236
     Name: AG_CRIMSON_ARROW_ATK
     Description: Crimson Arrow Attack
@@ -36269,15 +36271,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 84
+          Amount: 103
         - Level: 2
-          Amount: 87
+          Amount: 106
         - Level: 3
-          Amount: 90
+          Amount: 109
         - Level: 4
-          Amount: 93
+          Amount: 112
         - Level: 5
-          Amount: 96
+          Amount: 115
   - Id: 5238
     Name: IQ_POWERFUL_FAITH
     Description: Powerful Faith
@@ -36375,11 +36377,11 @@ Body:
       - Level: 2
         Area: 3
       - Level: 3
-        Area: 4
+        Area: 3
       - Level: 4
         Area: 4
       - Level: 5
-        Area: 5
+        Area: 4
     CastCancel: true
     Duration1:
       - Level: 1
@@ -36392,7 +36394,7 @@ Body:
         Time: 6000
       - Level: 5
         Time: 7000
-    Cooldown: 2000
+    Cooldown: 1500
     Requires:
       SpCost:
         - Level: 1
@@ -36405,9 +36407,6 @@ Body:
           Amount: 75
         - Level: 5
           Amount: 85
-      ItemCost:
-        - Item: Holy_Water
-          Amount: 1
     Status: Holy_Oil
   - Id: 5242
     Name: IQ_SINCERE_FAITH
@@ -36459,8 +36458,9 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Weapon
-    SplashArea: 5
+    SplashArea: 4
     CastCancel: true
+    AfterCastActDelay: 500
     Duration1: 150000
     Cooldown: 5000
     Requires:
@@ -36495,28 +36495,28 @@ Body:
     CastCancel: true
     AfterCastActDelay:
       - Level: 1
-        Time: 500
+        Time: 1500
       - Level: 2
-        Time: 400
+        Time: 1400
       - Level: 3
-        Time: 300
+        Time: 1300
       - Level: 4
-        Time: 200
+        Time: 1200
       - Level: 5
-        Time: 0
+        Time: 1000
     Cooldown: 700
     Requires:
       SpCost:
         - Level: 1
-          Amount: 70
+          Amount: 105
         - Level: 2
-          Amount: 75
+          Amount: 110
         - Level: 3
-          Amount: 80
+          Amount: 115
         - Level: 4
-          Amount: 85
+          Amount: 120
         - Level: 5
-          Amount: 90
+          Amount: 125
   - Id: 5245
     Name: IQ_FIRST_BRAND
     Description: First Brand
@@ -37148,12 +37148,12 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Holy
-    GiveAp: 7
+    GiveAp: 4
     CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 150
-    Duration1: 4500
-    Cooldown: 4500
+    Duration1: 2400
+    Cooldown: 2400
     FixedCastTime: 1500
     Requires:
       SpCost:
@@ -37366,34 +37366,35 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Holy
+    GiveAP: 2
     CastCancel: true
     CastTime: 4000
     AfterCastActDelay: 500
     Duration1: 20000
-    Cooldown: 1500
+    Cooldown: 1000
     FixedCastTime: 1000
     Requires:
       SpCost:
         - Level: 1
-          Amount: 94
+          Amount: 107
         - Level: 2
-          Amount: 96
+          Amount: 109
         - Level: 3
-          Amount: 98
+          Amount: 111
         - Level: 4
-          Amount: 100
+          Amount: 113
         - Level: 5
-          Amount: 102
+          Amount: 115
         - Level: 6
-          Amount: 104
+          Amount: 117
         - Level: 7
-          Amount: 106
+          Amount: 119
         - Level: 8
-          Amount: 108
+          Amount: 121
         - Level: 9
-          Amount: 110
+          Amount: 123
         - Level: 10
-          Amount: 112
+          Amount: 125
     Status: HandicapState_DeepSilence
   - Id: 5274
     Name: CD_ARBITRIUM_ATK
@@ -37701,19 +37702,19 @@ Body:
       - Level: 3
         Area: 1
       - Level: 4
-        Area: 2
+        Area: 1
       - Level: 5
         Area: 2
       - Level: 6
         Area: 2
       - Level: 7
-        Area: 3
+        Area: 2
       - Level: 8
-        Area: 3
+        Area: 2
       - Level: 9
         Area: 3
       - Level: 10
-        Area: 4
+        Area: 3
     GiveAp: 3
     CastCancel: true
     AfterCastActDelay: 500
@@ -37899,30 +37900,31 @@ Body:
     Hit: Multi_Hit
     HitCount: 3
     Element: Weapon
-    SplashArea: 2
+    GiveAP: 2
+    SplashArea: 
+      - Level: 1
+        Area: 2
+      - Level: 2
+        Area: 2
+      - Level: 3
+        Area: 2
+      - Level: 4
+        Area: 2
+      - Level: 5
+        Area: 2
+      - Level: 6
+        Area: 3
+      - Level: 7
+        Area: 3
+      - Level: 8
+        Area: 3
+      - Level: 9
+        Area: 3
+      - Level: 10
+        Area: 3
     CastCancel: true
     AfterCastActDelay: 300
-    Cooldown:
-      - Level: 1
-        Time: 3000
-      - Level: 2
-        Time: 2800
-      - Level: 3
-        Time: 2600
-      - Level: 4
-        Time: 2400
-      - Level: 5
-        Time: 2200
-      - Level: 6
-        Time: 2000
-      - Level: 7
-        Time: 1800
-      - Level: 8
-        Time: 1600
-      - Level: 9
-        Time: 1400
-      - Level: 10
-        Time: 1000
+    Cooldown: 700
     Requires:
       SpCost:
         - Level: 1
@@ -38214,15 +38216,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 46
+          Amount: 57
         - Level: 2
-          Amount: 53
+          Amount: 64
         - Level: 3
-          Amount: 60
+          Amount: 71
         - Level: 4
-          Amount: 67
+          Amount: 78
         - Level: 5
-          Amount: 74
+          Amount: 85
       Weapon:
         1hAxe: true
         2hAxe: true
@@ -38721,27 +38723,27 @@ Body:
         Time: 15000
     Cooldown:
       - Level: 1
-        Time: 3000
+        Time: 3100
       - Level: 2
-        Time: 2100
+        Time: 2200
       - Level: 3
-        Time: 1500
+        Time: 1600
       - Level: 4
-        Time: 900
+        Time: 1000
       - Level: 5
-        Time: 300
+        Time: 400
     Requires:
       SpCost:
         - Level: 1
-          Amount: 48
+          Amount: 80
         - Level: 2
-          Amount: 52
+          Amount: 84
         - Level: 3
-          Amount: 56
+          Amount: 88
         - Level: 4
-          Amount: 60
+          Amount: 72
         - Level: 5
-          Amount: 64
+          Amount: 76
       Weapon:
         Dagger: true
         1hSword: true
@@ -38938,7 +38940,7 @@ Body:
       Splash: true
     Range: 2
     Hit: Multi_Hit
-    HitCount: -5
+    HitCount: 5
     Element: Weapon
     SplashArea:
       - Level: 1
@@ -38966,47 +38968,47 @@ Body:
     AfterCastActDelay: 500
     Cooldown:
       - Level: 1
-        Time: 2000
+        Time: 2500
       - Level: 2
-        Time: 1900
+        Time: 2300
       - Level: 3
-        Time: 1700
+        Time: 2100
       - Level: 4
-        Time: 1500
+        Time: 1900
       - Level: 5
-        Time: 1300
+        Time: 1700
       - Level: 6
-        Time: 1100
+        Time: 1500
       - Level: 7
-        Time: 900
+        Time: 1300
       - Level: 8
-        Time: 700
+        Time: 1100
       - Level: 9
-        Time: 500
+        Time: 900
       - Level: 10
-        Time: 300
+        Time: 700
     Requires:
       SpCost:
         - Level: 1
-          Amount: 35
+          Amount: 45
         - Level: 2
-          Amount: 38
+          Amount: 48
         - Level: 3
-          Amount: 41
+          Amount: 51
         - Level: 4
-          Amount: 44
+          Amount: 54
         - Level: 5
-          Amount: 47
+          Amount: 57
         - Level: 6
-          Amount: 50
+          Amount: 60
         - Level: 7
-          Amount: 53
+          Amount: 63
         - Level: 8
-          Amount: 56
+          Amount: 66
         - Level: 9
-          Amount: 59
+          Amount: 69
         - Level: 10
-          Amount: 62
+          Amount: 72
   - Id: 5321
     Name: ABC_ABYSS_SQUARE
     Description: Abyss Square
@@ -39053,54 +39055,54 @@ Body:
       Critical: true
     Range: 9
     Hit: Multi_Hit
-    HitCount: 1
+    HitCount: 2
     Element: Weapon
     GiveAp: 1
     CastCancel: true
     AfterCastActDelay: 500
     Cooldown:
       - Level: 1
-        Time: 2000
+        Time: 2150
       - Level: 2
-        Time: 1800
+        Time: 1950
       - Level: 3
-        Time: 1600
+        Time: 1750
       - Level: 4
-        Time: 1400
+        Time: 1550
       - Level: 5
-        Time: 1200
+        Time: 1350
       - Level: 6
-        Time: 1000
+        Time: 1150
       - Level: 7
-        Time: 800
+        Time: 950
       - Level: 8
-        Time: 600
+        Time: 750
       - Level: 9
-        Time: 400
+        Time: 550
       - Level: 10
-        Time: 200
+        Time: 350
     Requires:
       SpCost:
         - Level: 1
-          Amount: 37
-        - Level: 2
-          Amount: 39
-        - Level: 3
-          Amount: 41
-        - Level: 4
-          Amount: 43
-        - Level: 5
-          Amount: 45
-        - Level: 6
           Amount: 47
-        - Level: 7
+        - Level: 2
           Amount: 49
-        - Level: 8
+        - Level: 3
           Amount: 51
-        - Level: 9
+        - Level: 4
           Amount: 53
-        - Level: 10
+        - Level: 5
           Amount: 55
+        - Level: 6
+          Amount: 57
+        - Level: 7
+          Amount: 59
+        - Level: 8
+          Amount: 61
+        - Level: 9
+          Amount: 63
+        - Level: 10
+          Amount: 65
       Weapon:
         Bow: true
       Ammo:
@@ -39206,8 +39208,8 @@ Body:
     HitCount: 1
     CastCancel: true
     AfterCastActDelay: 150
-    Duration1: 60000
-    Cooldown: 300000
+    Duration1: 180000
+    Cooldown: 180000
     FixedCastTime: 1750
     Requires:
       SpCost: 300
@@ -39226,7 +39228,6 @@ Body:
     HitCount: 1
     CastCancel: true
     CastTime: 800
-    Cooldown: 150
     AfterCastActDelay: 500
     Cooldown: 150
     FixedCastTime: 200
@@ -39265,38 +39266,38 @@ Body:
       - Level: 7
         Area: 3
       - Level: 8
-        Area: 4
+        Area: 3
       - Level: 9
         Area: 4
       - Level: 10
-        Area: 5
+        Area: 4
     CastCancel: true
     CastTime: 3500
     AfterCastActDelay: 500
-    Cooldown: 1500
+    Cooldown: 1200
     FixedCastTime: 500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 64
-        - Level: 2
-          Amount: 68
-        - Level: 3
-          Amount: 72
-        - Level: 4
-          Amount: 76
-        - Level: 5
-          Amount: 80
-        - Level: 6
           Amount: 84
-        - Level: 7
+        - Level: 2
           Amount: 88
-        - Level: 8
+        - Level: 3
           Amount: 92
-        - Level: 9
+        - Level: 4
           Amount: 96
-        - Level: 10
+        - Level: 5
           Amount: 100
+        - Level: 6
+          Amount: 104
+        - Level: 7
+          Amount: 108
+        - Level: 8
+          Amount: 112
+        - Level: 9
+          Amount: 116
+        - Level: 10
+          Amount: 120
       Weapon:
         Bow: true
       Ammo:
@@ -39530,9 +39531,9 @@ Body:
     GiveAp: 1
     CastCancel: true
     CastTime: 800
-    AfterCastActDelay: 300
+    AfterCastActDelay: 700
     Duration1: 10000
-    Cooldown: 150
+    Cooldown: 350
     FixedCastTime: 1000
     Requires:
       SpCost:
@@ -40337,7 +40338,7 @@ Body:
     CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 350
-    Cooldown: 1150
+    Cooldown: 350
     FixedCastTime: 1000
     Requires:
       SpCost:
@@ -40380,10 +40381,11 @@ Body:
       - Level: 4
         Area: 3
       - Level: 5
-        Area: 3
+        Area: 4
     GiveAp: 2
+    AfterCastActDelay: 500
     CastCancel: true
-    Cooldown: 300
+    Cooldown: 400
     Requires:
       SpCost:
         - Level: 1
@@ -41488,15 +41490,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 49
+          Amount: 72
         - Level: 2
-          Amount: 53
+          Amount: 76
         - Level: 3
-          Amount: 57
+          Amount: 80
         - Level: 4
-          Amount: 61
+          Amount: 84
         - Level: 5
-          Amount: 65
+          Amount: 88
       Weapon:
         Gatling: true
         Shotgun: true
@@ -41517,7 +41519,7 @@ Body:
     Element: Weapon
     GiveAp: 1
     AfterCastActDelay: 500
-    Cooldown: 300
+    Cooldown: 350
     CastCancel: true
     FixedCastTime: 1000
     Requires:
@@ -42242,7 +42244,7 @@ Body:
     MaxLevel: 5
     Type: Magic
     TargetType: Attack
-    Range: 9
+    Range: 11
     Hit: Single
     HitCount: 1
     Element: Endowed
@@ -42319,15 +42321,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 80
+          Amount: 106
         - Level: 2
-          Amount: 83
+          Amount: 109
         - Level: 3
-          Amount: 86
+          Amount: 112
         - Level: 4
-          Amount: 89
+          Amount: 115
         - Level: 5
-          Amount: 92
+          Amount: 118
       ItemCost:
         - Item: Soa_Charm
           Amount: 1
@@ -42543,7 +42545,7 @@ Body:
           Amount: 180
         - Level: 5
           Amount: 200
-      ApCost: 25
+      ApCost: 35
     Status: T_Fifth_God
   - Id: 5432
     Name: SOA_SOUL_OF_HEAVEN_AND_EARTH
@@ -42622,7 +42624,7 @@ Body:
     TargetType: Attack
     DamageFlags:
       Critical: true
-    Range: -9
+    Range: 11
     Hit: Multi_Hit
     HitCount: -2
     GiveAp: 1
@@ -42692,7 +42694,7 @@ Body:
     CastCancel: true
     FixedCastTime: 1000
     Requires:
-      SpCost: 68
+      SpCost: 72
     Status: Hogogong
   - Id: 5437
     Name: SH_HOGOGONG_STRIKE
@@ -42729,19 +42731,19 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 54
+          Amount: 67
         - Level: 2
-          Amount: 57
+          Amount: 70
         - Level: 3
-          Amount: 60
+          Amount: 73
         - Level: 4
-          Amount: 63
+          Amount: 76
         - Level: 5
-          Amount: 66
+          Amount: 79
         - Level: 6
-          Amount: 69
+          Amount: 82
         - Level: 7
-          Amount: 72
+          Amount: 85
   - Id: 5438
     Name: SH_COMMUNE_WITH_KI_SUL
     Description: Commune with Chulho
@@ -43019,7 +43021,7 @@ Body:
     MaxLevel: 7
     Type: Magic
     TargetType: Attack
-    Range: -9
+    Range: -11
     GiveAp: 1
     Hit: Multi_Hit
     HitCount: 1
@@ -43031,19 +43033,19 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 56
+          Amount: 47
         - Level: 2
-          Amount: 59
+          Amount: 50
         - Level: 3
-          Amount: 62
+          Amount: 53
         - Level: 4
-          Amount: 65
+          Amount: 56
         - Level: 5
-          Amount: 68
+          Amount: 59
         - Level: 6
-          Amount: 71
+          Amount: 62
         - Level: 7
-          Amount: 74
+          Amount: 65
   - Id: 5447
     Name: SH_TEMPORARY_COMMUNION
     Description: Temporary Communion
@@ -43113,7 +43115,7 @@ Body:
     DamageFlags:
       Splash: true
     SplashArea: 4
-    Knockback: 2
+    Knockback: 1
     CastCancel: true
     CastTime: 300
     AfterCastActDelay: 1000
@@ -43158,7 +43160,7 @@ Body:
     GiveAp: 2
     Element: Weapon
     AfterCastActDelay: 500
-    Cooldown: 300
+    Cooldown: 350
     Duration2: 5000
     Requires:
       SpCost:
@@ -43199,7 +43201,7 @@ Body:
     CastCancel: true
     CastTime: 1200
     AfterCastActDelay: 500
-    Cooldown: 300
+    Cooldown: 350
     FixedCastTime: 300
     Duration1: 5000
     Duration2: 1200
@@ -43241,7 +43243,7 @@ Body:
     CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 500
-    Cooldown: 300
+    Cooldown: 350
     FixedCastTime: 300
     Duration2: 2000
     Requires:
@@ -43649,25 +43651,25 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 71
+          Amount: 88
         - Level: 2
-          Amount: 74
+          Amount: 91
         - Level: 3
-          Amount: 77
+          Amount: 94
         - Level: 4
-          Amount: 80
+          Amount: 97
         - Level: 5
-          Amount: 83
+          Amount: 100
         - Level: 6
-          Amount: 86
+          Amount: 103
         - Level: 7
-          Amount: 89
+          Amount: 106
         - Level: 8
-          Amount: 92
+          Amount: 109
         - Level: 9
-          Amount: 95
+          Amount: 112
         - Level: 10
-          Amount: 98
+          Amount: 115
   - Id: 5459
     Name: HN_GROUND_GRAVITATION
     Description: Ground Gravitation
@@ -43752,25 +43754,25 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 55
-        - Level: 2
-          Amount: 60
-        - Level: 3
-          Amount: 65
-        - Level: 4
-          Amount: 70
-        - Level: 5
           Amount: 75
-        - Level: 6
+        - Level: 2
           Amount: 80
-        - Level: 7
+        - Level: 3
           Amount: 85
-        - Level: 8
+        - Level: 4
           Amount: 90
-        - Level: 9
+        - Level: 5
           Amount: 95
-        - Level: 10
+        - Level: 6
           Amount: 100
+        - Level: 7
+          Amount: 105
+        - Level: 8
+          Amount: 110
+        - Level: 9
+          Amount: 115
+        - Level: 10
+          Amount: 120
     Unit:
       Id: GROUND_GRAVITATION
       Range:
@@ -44120,9 +44122,9 @@ Body:
     CastTime: 1000
     Cooldown: 5000
     FixedCastTime: 500
-    Duration1: 4500
+    Duration1: 3500
     Requires:
-      SpCost: 84
+      SpCost: 124
     Unit:
       Id: TWINKLING_GALAXY
       Range:
@@ -44136,7 +44138,7 @@ Body:
           Size: 5
         - Level: 5
           Size: 4
-      Interval: 300
+      Interval: 500
       Target: Enemy
       Flag:
         PathCheck: true
@@ -44190,23 +44192,23 @@ Body:
     HitCount: -3
     GiveAp: 3
     Element: Weapon
-    SplashArea: 3
-    Cooldown: 5000
+    SplashArea: 2
+    Cooldown: 3500
     CastCancel: true
     FixedCastTime: 500
-    Duration1: 4500
+    Duration1: 2500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 51
+          Amount: 98
         - Level: 2
-          Amount: 54
+          Amount: 101
         - Level: 3
-          Amount: 57
+          Amount: 104
         - Level: 4
-          Amount: 60
+          Amount: 107
         - Level: 5
-          Amount: 63
+          Amount: 110
     Unit:
       Id: STAR_CANNON
       Range:
@@ -44220,7 +44222,7 @@ Body:
           Size: 5
         - Level: 5
           Size: 4
-      Interval: 300
+      Interval: 500
       Target: Enemy
       Flag:
         PathCheck: true
@@ -44240,7 +44242,7 @@ Body:
     FixedCastTime: 1000
     Cooldown: 2000
     Requires:
-      ApCost: 35
+      ApCost: 70
       SpCost: 85
   - Id: 5475
     Name: SKE_ENCHANTING_SKY
@@ -44436,7 +44438,7 @@ Body:
       - Level: 4
         Area: 2
       - Level: 5
-        Area: 3
+        Area: 2
       - Level: 6
         Area: 3
       - Level: 7
@@ -44444,11 +44446,11 @@ Body:
       - Level: 8
         Area: 3
       - Level: 9
-        Area: 4
+        Area: 3
       - Level: 10
-        Area: 4
+        Area: 3
     AfterCastActDelay: 250
-    Cooldown: 500
+    Cooldown: 400
     CastCancel: true
     FixedCastTime:
       - Level: 1
@@ -44474,37 +44476,40 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 38
+          Amount: 55
         - Level: 2
-          Amount: 41
+          Amount: 58
         - Level: 3
-          Amount: 44
+          Amount: 61
         - Level: 4
-          Amount: 47
+          Amount: 64
         - Level: 5
-          Amount: 50
+          Amount: 67
         - Level: 6
-          Amount: 53
+          Amount: 70
         - Level: 7
-          Amount: 56
+          Amount: 73
         - Level: 8
-          Amount: 59
+          Amount: 76
         - Level: 9
-          Amount: 62
+          Amount: 79
         - Level: 10
-          Amount: 65
+          Amount: 82
   - Id: 5482
     Name: SS_KAGEGISSEN
     Description: Shadow Flash
     MaxLevel: 10
     Type: Weapon
     TargetType: Attack
-    Range: 1
+    Range: 2
     Hit: Multi_Hit
     HitCount: -4
     GiveAp: 1
     Element: Weapon
-    SplashArea: 1
+    DamageFlags:
+      Splash: true
+      Critical: true
+    SplashArea: 3
     ActiveInstance: 10
     AfterCastActDelay: 250
     Cooldown: 500
@@ -44605,12 +44610,14 @@ Body:
     Description: Huuma Shuriken - Construct
     MaxLevel: 10
     Type: Weapon
-    TargetType: Ground
-    Range: 1
+    TargetType: Attack
+    Range: 9
     Hit: Multi_Hit
     HitCount: -3
     Element: Weapon
-    SplashArea: 2
+    DamageFlags:
+      Splash: true
+    SplashArea: 4
     ActiveInstance: 13
     CastCancel: true
     CastTime: 1200
@@ -44802,15 +44809,15 @@ Body:
     Description: Red Flame Cannon
     MaxLevel: 10
     Type: Magic
-    TargetType: Ground
-    Range: 1
+    TargetType: Attack
+    Range: 9
     Hit: Multi_Hit
     HitCount: -3
     ActiveInstance: 7
     Element: Fire
     DamageFlags:
       Splash: true
-    SplashArea: 1
+    SplashArea: 3
     CastCancel: true
     CastTime: 2000
     Cooldown: 700
@@ -44818,25 +44825,25 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 65
+          Amount: 53
         - Level: 2
-          Amount: 68
+          Amount: 56
         - Level: 3
-          Amount: 71
+          Amount: 59
         - Level: 4
-          Amount: 74
+          Amount: 62
         - Level: 5
-          Amount: 77
+          Amount: 65
         - Level: 6
-          Amount: 80
+          Amount: 68
         - Level: 7
-          Amount: 83
+          Amount: 71
         - Level: 8
-          Amount: 86
+          Amount: 74
         - Level: 9
-          Amount: 89
+          Amount: 77
         - Level: 10
-          Amount: 92
+          Amount: 80
       ItemCost:
         - Item: SS_Charm_F
           Amount: 1
@@ -44880,25 +44887,25 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 52
+          Amount: 40
         - Level: 2
-          Amount: 56
+          Amount: 44
         - Level: 3
-          Amount: 60
+          Amount: 48
         - Level: 4
-          Amount: 64
+          Amount: 52
         - Level: 5
-          Amount: 68
+          Amount: 56
         - Level: 6
-          Amount: 72
+          Amount: 60
         - Level: 7
-          Amount: 76
+          Amount: 64
         - Level: 8
-          Amount: 80
+          Amount: 68
         - Level: 9
-          Amount: 84
+          Amount: 72
         - Level: 10
-          Amount: 88
+          Amount: 76
       ItemCost:
         - Item: SS_Charm_W
           Amount: 1
@@ -44907,15 +44914,15 @@ Body:
     Description: Thundering Cannon
     MaxLevel: 10
     Type: Magic
-    TargetType: Ground
-    Range: 1
+    TargetType: Attack
+    Range: 9
     Hit: Multi_Hit
     HitCount: -2
     ActiveInstance: 13
     Element: Wind
     DamageFlags:
       Splash: true
-    SplashArea: 1
+    SplashArea: 3
     CastCancel: true
     CastTime: 2000
     Cooldown: 700
@@ -44923,25 +44930,25 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 47
+          Amount: 35
         - Level: 2
-          Amount: 52
+          Amount: 40
         - Level: 3
-          Amount: 57
+          Amount: 45
         - Level: 4
-          Amount: 62
+          Amount: 50
         - Level: 5
-          Amount: 67
+          Amount: 55
         - Level: 6
-          Amount: 72
+          Amount: 60
         - Level: 7
-          Amount: 77
+          Amount: 65
         - Level: 8
-          Amount: 82
+          Amount: 70
         - Level: 9
-          Amount: 87
+          Amount: 75
         - Level: 10
-          Amount: 92
+          Amount: 80
       ItemCost:
         - Item: SS_Charm_L
           Amount: 1
@@ -44951,7 +44958,7 @@ Body:
     MaxLevel: 10
     Type: Magic
     TargetType: Attack
-    Range: 13
+    Range: 9
     Hit: Single
     HitCount: 1
     Element: Earth
@@ -44959,25 +44966,25 @@ Body:
       Splash: true
     SplashArea:
       - Level: 1
-        Area: 2
+        Area: 1
       - Level: 2
-        Area: 2
+        Area: 1
       - Level: 3
-        Area: 2
+        Area: 1
       - Level: 4
-        Area: 2
+        Area: 1
       - Level: 5
-        Area: 3
+        Area: 1
       - Level: 6
-        Area: 3
+        Area: 2
       - Level: 7
-        Area: 3
+        Area: 2
       - Level: 8
-        Area: 3
+        Area: 2
       - Level: 9
-        Area: 4
+        Area: 2
       - Level: 10
-        Area: 4
+        Area: 2
     CastCancel: true
     CastTime: 3000
     Cooldown: 300
@@ -44985,25 +44992,25 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 52
+          Amount: 29
         - Level: 2
-          Amount: 56
+          Amount: 33
         - Level: 3
-          Amount: 60
+          Amount: 37
         - Level: 4
-          Amount: 64
+          Amount: 41
         - Level: 5
-          Amount: 68
+          Amount: 45
         - Level: 6
-          Amount: 72
+          Amount: 49
         - Level: 7
-          Amount: 76
+          Amount: 53
         - Level: 8
-          Amount: 80
+          Amount: 57
         - Level: 9
-          Amount: 84
+          Amount: 61
         - Level: 10
-          Amount: 88
+          Amount: 65
       ItemCost:
         - Item: SS_Charm_G
           Amount: 1
@@ -45279,7 +45286,7 @@ Body:
     CastTime: 1500
     FixedCastTime: 500
     AfterCastActDelay: 500
-    Cooldown: 700
+    Cooldown: 500
     Requires:
       SpCost:
         - Level: 1
@@ -45321,7 +45328,7 @@ Body:
     CastTime: 1000
     FixedCastTime: 500
     AfterCastActDelay: 500
-    Cooldown: 250
+    Cooldown: 350
     Requires:
       SpCost:
         - Level: 1
@@ -45346,7 +45353,7 @@ Body:
     Flags:
       AllowOnMado: true
     Hit: Multi_Hit
-    HitCount: 3
+    HitCount: 5
     Element: Weapon
     SplashArea:
       - Level: 1
@@ -45370,29 +45377,30 @@ Body:
       - Level: 10
         Area: 3
     CastCancel: true
-    Cooldown: 300
+    AfterCastActDelay: 250
+    Cooldown: 500
     Requires:
       SpCost:
         - Level: 1
-          Amount: 51
+          Amount: 68
         - Level: 2
-          Amount: 54
+          Amount: 71
         - Level: 3
-          Amount: 57
+          Amount: 74
         - Level: 4
-          Amount: 60
+          Amount: 77
         - Level: 5
-          Amount: 63
+          Amount: 80
         - Level: 6
-          Amount: 66
+          Amount: 83
         - Level: 7
-          Amount: 69
+          Amount: 86
         - Level: 8
-          Amount: 72
+          Amount: 89
         - Level: 9
-          Amount: 75
+          Amount: 92
         - Level: 10
-          Amount: 78
+          Amount: 95
       Weapon:
         1hAxe: true
         2hAxe: true
@@ -45415,15 +45423,15 @@ Body:
     Requires:
       SpCost:
         - Level: 1
-          Amount: 58
+          Amount: 81
         - Level: 2
-          Amount: 62
+          Amount: 85
         - Level: 3
-          Amount: 66
+          Amount: 89
         - Level: 4
-          Amount: 70
+          Amount: 93
         - Level: 5
-          Amount: 74
+          Amount: 97
   - Id: 6006
     Name: BO_MAYHEMIC_THORNS
     Description: Mayhemic Thorns

--- a/db/re/skill_db.yml
+++ b/db/re/skill_db.yml
@@ -34935,15 +34935,15 @@ Body:
         Time: 1000
     Cooldown:
       - Level: 1
-        Time: 30000
+        Time: 12000
       - Level: 2
-        Time: 60000
+        Time: 24000
       - Level: 3
-        Time: 90000
+        Time: 36000
       - Level: 4
-        Time: 120000
+        Time: 48000
       - Level: 5
-        Time: 150000
+        Time: 60000
     Requires:
       SpCost:
         - Level: 1
@@ -34968,7 +34968,7 @@ Body:
       Critical: true
     Range: 1
     Hit: Multi_Hit
-    HitCount: 2
+    HitCount: 3
     Element: Weapon
     Requires:
       SpCost: 1
@@ -35448,7 +35448,7 @@ Body:
     Element: Water
     CastCancel: true
     CastTime: 3000
-    AfterCastActDelay: 250
+    AfterCastActDelay: 750
     Duration1: 4000
     Cooldown: 5000
     FixedCastTime: 1500
@@ -35495,7 +35495,7 @@ Body:
     Element: Dark
     CastCancel: true
     CastTime: 4000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 750
     Duration1: 4000
     Cooldown: 4000
     FixedCastTime: 1500
@@ -35552,7 +35552,7 @@ Body:
         Area: 4
     CastCancel: true
     CastTime: 4000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1:
       - Level: 1
         Time: 1200
@@ -35680,7 +35680,7 @@ Body:
     Element: Earth
     CastCancel: true
     CastTime: 3000
-    AfterCastActDelay: 250
+    AfterCastActDelay: 750
     Duration1: 4000
     Cooldown: 4000
     FixedCastTime: 1500
@@ -35737,7 +35737,7 @@ Body:
         Area: 4
     CastCancel: true
     CastTime: 4000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1:
       - Level: 1
         Time: 1200
@@ -35899,7 +35899,7 @@ Body:
     Element: Wind
     CastCancel: true
     CastTime: 3000
-    AfterCastActDelay: 250
+    AfterCastActDelay: 750
     Duration1: 3000
     Cooldown: 5000
     FixedCastTime: 1500
@@ -35950,7 +35950,7 @@ Body:
     Element: Fire
     CastCancel: true
     CastTime: 3000
-    AfterCastActDelay: 250
+    AfterCastActDelay: 750
     Duration1: 5000
     Cooldown: 5000
     FixedCastTime: 1500
@@ -36018,7 +36018,7 @@ Body:
         Area: 5
     CastCancel: true
     CastTime: 4000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 1000
     Duration1: 6000
     Cooldown: 6000
     FixedCastTime: 2000
@@ -36078,11 +36078,11 @@ Body:
     CastTime: 2000
     AfterCastActDelay: 500
     Duration1: 300000
-    Cooldown: 300000
+    Cooldown: 60000
     FixedCastTime: 2500
     Requires:
       SpCost: 60
-      ApCost: 150
+      ApCost: 125
     Status: Climax
   - Id: 5233
     Name: AG_ROCK_DOWN
@@ -36718,8 +36718,9 @@ Body:
     Element: Weapon
     SplashArea: 3
     CastCancel: true
+    AfterCastActDelay: 500
     Duration1: 600000
-    Cooldown: 1000
+    Cooldown: 700
     Requires:
       SpCost:
         - Level: 1
@@ -36746,6 +36747,7 @@ Body:
     Element: Weapon
     SplashArea: 3
     CastCancel: true
+    AfterCastActDelay: 700
     Cooldown: 1000
     Requires:
       SpCost:
@@ -36838,8 +36840,7 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 1000
-    FixedCastTime: 1000
+    FixedCastTime: 500
     Requires:
       SpCost: 50
       State: Shield
@@ -36856,16 +36857,16 @@ Body:
       Toggleable: true
     Hit: Single
     HitCount: 1
-    GiveAp: 15
     SplashArea: 10
     CastCancel: true
     CastTime: 2000
-    AfterCastActDelay: 1000
-    Duration1: 60000
-    Cooldown: 15000
+    AfterCastActDelay: 300
+    Duration1: 45000
+    Cooldown: 25000
     FixedCastTime: 1000
     Requires:
       SpCost: 60
+      ApCost: 35
       Status:
         Guard_Stance: true
     Status: Guardian_S
@@ -36907,8 +36908,7 @@ Body:
     Hit: Single
     HitCount: 1
     CastCancel: true
-    CastTime: 1000
-    FixedCastTime: 1000
+    FixedCastTime: 500
     Requires:
       SpCost: 50
     Status: Attack_Stance
@@ -36986,7 +36986,7 @@ Body:
     Range: 9
     Hit: Single
     HitCount: 1
-    Element: Weapon
+    Element: Neutral
     SplashArea: 3
     CastCancel: true
     CastTime: 1000
@@ -37072,7 +37072,7 @@ Body:
     HitCount: -7
     Element: Weapon
     SplashArea: 3
-    GiveAp: 3
+    GiveAp: 5
     CastCancel: true
     CastTime: 500
     AfterCastActDelay: 500
@@ -37108,7 +37108,7 @@ Body:
     HitCount: 3
     Element: Weapon
     SplashArea: 3
-    GiveAp: 3
+    GiveAp: 5
     CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 500
@@ -37148,7 +37148,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Holy
-    GiveAp: 4
+    GiveAp: 6
     CastCancel: true
     CastTime: 1000
     AfterCastActDelay: 150
@@ -37525,15 +37525,16 @@ Body:
     Range: 9
     Hit: Multi_Hit
     HitCount: -10
-    Element: Holy
+    Element: Neutral
     CastCancel: true
+    AfterCastActDelay: 500
     CastTime: 3000
     Duration1: 12000
     Cooldown: 5000
     FixedCastTime: 2000
     Requires:
       SpCost: 150
-      ApCost: 30
+      ApCost: 20
     Unit:
       Id: Pneumaticus_Procella
       Range:
@@ -38200,7 +38201,7 @@ Body:
         Area: 3
     GiveAp: 3
     CastCancel: true
-    AfterCastActDelay: 250
+    AfterCastActDelay: 700
     Duration1:
       - Level: 1
         Time: 10000
@@ -38872,7 +38873,7 @@ Body:
         Time: 1500
       - Level: 5
         Time: 1000
-    Cooldown: 60000
+    Cooldown: 30000
     Requires:
       SpCost:
         - Level: 1
@@ -38903,7 +38904,7 @@ Body:
     FixedCastTime: 1000
     Requires:
       SpCost: 100
-      ApCost: 150
+      ApCost: 120
     Status: Abyss_Slayer
   - Id: 5319
     Name: ABC_ABYSS_STRIKE
@@ -38911,6 +38912,7 @@ Body:
     MaxLevel: 10
     Type: Magic
     TargetType: Ground
+    Element: Fire
     Range: 9
     Hit: Single
     HitCount: 1
@@ -38918,11 +38920,11 @@ Body:
     CastTime: 4000
     AfterCastActDelay: 500
     Duration1: 100
-    Cooldown: 3000
+    Cooldown: 700
     FixedCastTime: 1000
     Requires:
       SpCost: 125
-      ApCost: 15
+      ApCost: 10
     Unit:
       Id: Dummyskill
       Range: 4
@@ -39057,7 +39059,7 @@ Body:
     Hit: Multi_Hit
     HitCount: 2
     Element: Weapon
-    GiveAp: 1
+    GiveAp: 3
     CastCancel: true
     AfterCastActDelay: 500
     Cooldown:
@@ -39209,11 +39211,11 @@ Body:
     CastCancel: true
     AfterCastActDelay: 150
     Duration1: 180000
-    Cooldown: 180000
+    Cooldown: 60000
     FixedCastTime: 1750
     Requires:
       SpCost: 300
-      ApCost: 200
+      ApCost: 125
     Status: CalamityGale
   - Id: 5329
     Name: WH_HAWKBOOMERANG
@@ -39274,7 +39276,7 @@ Body:
     CastCancel: true
     CastTime: 3500
     AfterCastActDelay: 500
-    Cooldown: 1200
+    Cooldown: 700
     FixedCastTime: 500
     Requires:
       SpCost:
@@ -40942,7 +40944,7 @@ Body:
     GiveAp: 5
     CastCancel: true
     CastTime: 5000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 700
     Duration1: 3000
     Duration2: 10000
     Cooldown: 2000
@@ -40981,7 +40983,7 @@ Body:
     GiveAp: 5
     CastCancel: true
     CastTime: 5000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 700
     Duration1: 3000
     Duration2: 20000
     Cooldown: 2000
@@ -41020,7 +41022,7 @@ Body:
     GiveAp: 5
     CastCancel: true
     CastTime: 5000
-    AfterCastActDelay: 500
+    AfterCastActDelay: 700
     Duration1: 3000
     Duration2: 20000
     Cooldown: 2000
@@ -41101,7 +41103,7 @@ Body:
     CastTime: 5000
     AfterCastActDelay: 1000
     Duration1: 1500000
-    Cooldown: 900000
+    Cooldown: 60000
     FixedCastTime: 3000
     Requires:
       SpCost: 100
@@ -41122,7 +41124,7 @@ Body:
     CastTime: 5000
     AfterCastActDelay: 1000
     Duration1: 1500000
-    Cooldown: 900000
+    Cooldown: 60000
     FixedCastTime: 3000
     Requires:
       SpCost: 100
@@ -41143,7 +41145,7 @@ Body:
     CastTime: 5000
     AfterCastActDelay: 1000
     Duration1: 1500000
-    Cooldown: 900000
+    Cooldown: 60000
     FixedCastTime: 3000
     Requires:
       SpCost: 100
@@ -41164,7 +41166,7 @@ Body:
     CastTime: 5000
     AfterCastActDelay: 1000
     Duration1: 1500000
-    Cooldown: 900000
+    Cooldown: 60000
     FixedCastTime: 3000
     Requires:
       SpCost: 100
@@ -41185,7 +41187,7 @@ Body:
     CastTime: 5000
     AfterCastActDelay: 1000
     Duration1: 1500000
-    Cooldown: 900000
+    Cooldown: 60000
     FixedCastTime: 3000
     Requires:
       SpCost: 100
@@ -41204,11 +41206,11 @@ Body:
     CastCancel: true
     CastTime: 8000
     AfterCastActDelay: 500
-    Cooldown: 5000
+    Cooldown: 2000
     FixedCastTime: 1500
     Requires:
       SpCost: 140
-      ApCost: 30
+      ApCost: 15
   - Id: 5381
     Name: EM_ELEMENTAL_VEIL
     Description: Elemental Veil
@@ -41273,7 +41275,7 @@ Body:
       Splash: true
     Range: 1
     Hit: Multi_Hit
-    HitCount: 2
+    HitCount: 5
     SplashArea: 4
     Requires:
       SpCost: 1
@@ -41482,7 +41484,7 @@ Body:
         Area: 3
       - Level: 5
         Area: 3
-    GiveAp: 1
+    GiveAp: 2
     AfterCastActDelay: 1000
     Cooldown: 500
     CastCancel: true
@@ -41517,7 +41519,7 @@ Body:
     Hit: Single
     HitCount: 1
     Element: Weapon
-    GiveAp: 1
+    GiveAp: 2
     AfterCastActDelay: 500
     Cooldown: 350
     CastCancel: true
@@ -41564,7 +41566,7 @@ Body:
         Area: 3
       - Level: 5
         Area: 3
-    GiveAp: 1
+    GiveAp: 2
     AfterCastActDelay: 1000
     Cooldown: 500
     CastCancel: true
@@ -41599,7 +41601,7 @@ Body:
     Hit: Multi_Hit
     HitCount: 6
     Element: Weapon
-    GiveAp: 1
+    GiveAp: 2
     AfterCastActDelay: 1000
     Cooldown: 500
     CastCancel: true
@@ -41645,7 +41647,7 @@ Body:
         Area: 3
       - Level: 5
         Area: 3
-    GiveAp: 1
+    GiveAp: 2
     AfterCastActDelay: 1000
     Cooldown: 500
     CastCancel: true
@@ -45377,7 +45379,7 @@ Body:
       - Level: 10
         Area: 3
     CastCancel: true
-    AfterCastActDelay: 250
+    AfterCastActDelay: 700
     Cooldown: 500
     Requires:
       SpCost:

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -1,4 +1,4 @@
-# This file is a part of rAthena.
+﻿# This file is a part of rAthena.
 #   Copyright(C) 2022 rAthena Development Team
 #   https://rathena.org - https://github.com/rathena
 #
@@ -5735,6 +5735,9 @@ Body:
       All: true
     Flags:
       DisplayPc: true
+      NoDispell: true
+      NoBanishingBuster: true
+      NoClearance: true
   - Status: Kings_Grace
     Icon: EFST_KINGS_GRACE
     DurationLookup: LG_KINGS_GRACE
@@ -9166,6 +9169,10 @@ Body:
       Smatk: true
     EndOnStart:
       T_Fourth_God: true
+    Flags:
+      NoDispell: true
+      NoBanishingBuster: true
+      NoClearance: true
   - Status: Heaven_and_Earth
     Icon: EFST_HEAVEN_AND_EARTH
     DurationLookup: SOA_SOUL_OF_HEAVEN_AND_EARTH

--- a/db/re/status.yml
+++ b/db/re/status.yml
@@ -7921,6 +7921,9 @@ Body:
       BlEffect: true
       DisplayPc: true
       SendVal1: true
+      NoBanishingBuster: true
+      NoDispell: true
+      NoClearance: true
   - Status: Shadow_Weapon
     Icon: EFST_SHADOW_WEAPON
     DurationLookup: SHC_ENCHANTING_SHADOW
@@ -7967,6 +7970,9 @@ Body:
     Flags:
       BlEffect: true
       DisplayPc: true
+      NoBanishingBuster: true
+      NoDispell: true
+      NoClearance: true
   - Status: Ultimate_S
     Icon: EFST_ULTIMATE_S
     DurationLookup: IG_ULTIMATE_SACRIFICE
@@ -8831,6 +8837,10 @@ Body:
     DurationLookup: NW_HIDDEN_CARD
     CalcFlags:
       All: true
+    Flags:
+      NoBanishingBuster: true
+      NoDispell: true
+      NoClearance: true
   - Status: Grenade_Fragment_1
     Icon: EFST_GRENADE_FRAGMENT_1
     DurationLookup: NW_GRENADE_FRAGMENT

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -1911,7 +1911,7 @@ int64 battle_calc_damage(struct block_list *src,struct block_list *bl,struct Dam
 			switch (skill_id) {
 			case HN_SHIELD_CHAIN_RUSH:
 			case HN_DOUBLEBOWLINGBASH:
-				damage += damage * 70 / 100; 
+				damage += damage * 120 / 100; 
 				break;
 			case HN_MEGA_SONIC_BLOW:
 			case HN_SPIRAL_PIERCE_MAX:
@@ -5743,7 +5743,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio += skillratio * sc->getSCE(SC_LIGHTOFSTAR)->val2 / 100;
 			break;
 		case DK_SERVANTWEAPON_ATK:
-			skillratio += -100 + 500 + 400 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 350 + 900 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case DK_SERVANT_W_PHANTOM:
@@ -5756,7 +5756,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			break;
 		case DK_HACKANDSLASHER:
 		case DK_HACKANDSLASHER_ATK:
-			skillratio += -100 + 200 + 750 * skill_lv;
+			skillratio += -100 + 550 + 800 * skill_lv;
 			skillratio += 7 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
@@ -5767,7 +5767,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case DK_MADNESS_CRUSHER:
-			skillratio += -100 + 350 + 1600 * skill_lv + 10 * sstatus->pow;
+			skillratio += -100 + 4000 * skill_lv + 10 * sstatus->pow;
 			if( sd != nullptr ){
 				int16 index = sd->equip_index[EQI_HAND_R];
 
@@ -5780,7 +5780,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio *= 2;
 			break;
 		case DK_STORMSLASH:
-			skillratio += -100 + 200 + 400 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 50 + 800 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			if (sc && sc->getSCE(SC_GIANTGROWTH) && rnd()%100 < 60)
 				skillratio *= 2;
@@ -5804,10 +5804,10 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_EXPOSION_BLASTER:
-			skillratio += -100 + 2400 * skill_lv + 10 * sstatus->pow;
+			skillratio += -100 + 2690 * skill_lv + 10 * sstatus->pow;
 
 			if( tsc != nullptr && tsc->getSCE( SC_HOLY_OIL ) ){
-				skillratio += 350 + 1050 * skill_lv + 5 * sstatus->pow;
+				skillratio += 350 + 880 * skill_lv + 5 * sstatus->pow;
 			}
 
 			RE_LVL_DMOD(100);
@@ -5829,7 +5829,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_THIRD_PUNISH:
-			skillratio += -100 + 350 + 1500 * skill_lv + 10 * sstatus->pow;
+			skillratio += -100 + 450 + 1800 * skill_lv + 10 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_THIRD_FLAME_BOMB:
@@ -5850,8 +5850,8 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio += skillratio * i / 100;
 			break;
 		case IG_SHIELD_SHOOTING:
-			skillratio += -100 + 650 + 2850 * skill_lv + 7 * sstatus->pow;
-			skillratio += skill_lv * 50 * pc_checkskill( sd, IG_SHIELD_MASTERY );
+			skillratio += -100 + 800 + 3500 * skill_lv + 7 * sstatus->pow;
+			skillratio += skill_lv * 100 * pc_checkskill( sd, IG_SHIELD_MASTERY );
 			if (sd) { // Damage affected by the shield's weight and refine. Need official formula. [Rytech]
 				short index = sd->equip_index[EQI_HAND_L];
 
@@ -5863,7 +5863,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IG_OVERSLASH:
-			skillratio += -100 + (160 + pc_checkskill(sd, IG_SPEAR_SWORD_M) * 25) * skill_lv + 7 * sstatus->pow;
+			skillratio += -100 + (220 + pc_checkskill(sd, IG_SPEAR_SWORD_M) * 50) * skill_lv + 7 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			if ((i = pc_checkskill_imperial_guard(sd, 3)) > 0)
 				skillratio += skillratio * i / 100;
@@ -5886,7 +5886,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_SAVAGE_IMPACT:
-			skillratio += -100 + 90 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 50 + 100 * skill_lv + 5 * sstatus->pow;
 
 			if( sc != nullptr && sc->getSCE( SC_SHADOW_EXCEED ) ){
 				skillratio += 20 * skill_lv + 3 * sstatus->pow;	// !TODO: check POW ratio
@@ -5895,16 +5895,16 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_ETERNAL_SLASH:
-			skillratio += -100 + 265 * skill_lv + 2 * sstatus->pow;
+			skillratio += -100 + 500 * skill_lv + 2 * sstatus->pow;
 
 			if( sc != nullptr && sc->getSCE( SC_SHADOW_EXCEED ) ){
-				skillratio += 100 * skill_lv + sstatus->pow;
+				skillratio += 120 * skill_lv + sstatus->pow;
 			}
 
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_SHADOW_STAB:
-			skillratio += -100 + 400 * skill_lv + 7 * sstatus->pow;
+			skillratio += -100 + 650 * skill_lv + 7 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_IMPACT_CRATER:
@@ -5918,14 +5918,14 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case MT_AXE_STOMP:
-			skillratio += -100 + 400 + 950 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 200 + 1200 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case MT_MIGHTY_SMASH:
-			skillratio += -100 + 25 + 180 * skill_lv;
+			skillratio += -100 + 40 + 210 * skill_lv;
 			skillratio += 5 * sstatus->pow;
 			if (sc && sc->getSCE(SC_AXE_STOMP)) {
-				skillratio += 25;
+				skillratio += 40;
 				skillratio += 5 * sstatus->pow;
 			}
 			RE_LVL_DMOD(100);
@@ -5941,17 +5941,17 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case MT_SPARK_BLASTER:
-			skillratio += -100 + 250 + 900 * skill_lv;
+			skillratio += -100 + 450 + 1200 * skill_lv;
 			skillratio += 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case MT_TRIPLE_LASER:
-			skillratio += -100 + 550 + 900 * skill_lv;
+			skillratio += -100 + 400 + 1200 * skill_lv;
 			skillratio += 12 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_ABYSS_DAGGER:
-			skillratio += -100 + 100 + 900 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 150 + 1440 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_UNLUCKY_RUSH:
@@ -5963,15 +5963,15 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_CHAIN_REACTION_SHOT_ATK:
-			skillratio += -100 + 600 + 2350 * skill_lv + 15 * sstatus->con;
+			skillratio += -100 + 1600 + 2350 * skill_lv + 15 * sstatus->con;
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_DEFT_STAB:
-			skillratio += -100 + 250 + 350 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 400 + 500 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_FRENZY_SHOT:
-			skillratio += -100 + 150 + 600 * skill_lv + 15 * sstatus->con;
+			skillratio += -100 + 250 + 800 * skill_lv + 15 * sstatus->con;
 			RE_LVL_DMOD(100);
 			break;
 		case WH_HAWKRUSH:
@@ -5985,17 +5985,17 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case WH_GALESTORM:
-			skillratio += -100 + 1000 * skill_lv + 10 * sstatus->con;
+			skillratio += -100 + 3300 * skill_lv + 10 * sstatus->con;
 			RE_LVL_DMOD(100);
 			if (sc && sc->getSCE(SC_CALAMITYGALE) && (tstatus->race == RC_BRUTE || tstatus->race == RC_FISH))
 				skillratio += skillratio * 50 / 100;
 			break;
 		case WH_CRESCIVE_BOLT:
-			skillratio += -100 + 400 + 900 * skill_lv + 5 * sstatus->con;
+			skillratio += -100 + 500 + 1100 * skill_lv + 5 * sstatus->con;
 			RE_LVL_DMOD(100);
 			if (sc) {
 				if (sc->getSCE(SC_CRESCIVEBOLT))
-					skillratio += skillratio * (10 * sc->getSCE(SC_CRESCIVEBOLT)->val1) / 100;
+					skillratio += skillratio * (40 * sc->getSCE(SC_CRESCIVEBOLT)->val1) / 100;
 
 				if (sc->getSCE(SC_CALAMITYGALE)) {
 					skillratio += skillratio * 20 / 100;
@@ -6044,7 +6044,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 
 			break;
 		case BO_EXPLOSIVE_POWDER:
-			skillratio += -100 + 400 + 550 * skill_lv;
+			skillratio += -100 + 400 + 670 * skill_lv;
 			skillratio += 5 * sstatus->pow;
 			if (sc && sc->getSCE(SC_RESEARCHREPORT))
 				skillratio += 100 * skill_lv;
@@ -6094,13 +6094,13 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			}
 			break;
 		case TR_RHYTHMSHOOTING:
-			skillratio += -100 + 450 + 650 * skill_lv;
+			skillratio += -100 + 300 + 1000 * skill_lv;
 
 			if (sd && pc_checkskill(sd, TR_STAGE_MANNER) > 0)
 				skillratio += 5 * sstatus->con;
 
 			if (tsc && tsc->getSCE(SC_SOUNDBLEND))
-				skillratio += 350 + 100 * skill_lv + 2 * sstatus->con;
+				skillratio += 300 + 100 * skill_lv + 2 * sstatus->con;
 
 			RE_LVL_DMOD(100);
 			if (sc && sc->getSCE(SC_MYSTIC_SYMPHONY)) {
@@ -6197,7 +6197,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case SS_KAGENOMAI:
-			skillratio += -100 + 550 + (750 + pc_checkskill(sd, SS_KAGEGARI) * 50) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 750 + (900 + pc_checkskill(sd, SS_KAGEGARI) * 50) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			if (wd->miscflag & SKILL_ALTDMG_FLAG)
 				skillratio = skillratio * 3 / 10;
@@ -6207,11 +6207,11 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case SS_FUUMAKOUCHIKU:
-			skillratio += -100 + 600 + (1200 + pc_checkskill(sd, SS_FUUMASHOUAKU) * 30) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 900 + (1500 + pc_checkskill(sd, SS_FUUMASHOUAKU) * 30) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SS_FUUMAKOUCHIKU_BLASTING:
-			skillratio += -100 + 600 + (1500 + pc_checkskill(sd, SS_FUUMASHOUAKU) * 30) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 900 + (1750 + pc_checkskill(sd, SS_FUUMASHOUAKU) * 30) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SS_KUNAIWAIKYOKU:
@@ -6221,21 +6221,21 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio = skillratio * 3 / 10;
 			break;
 		case SS_KUNAIKUSSETSU:
-			skillratio += -100 + 200 + (360 + pc_checkskill(sd, SS_KUNAIKAITEN) * 10) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 250 + (420 + pc_checkskill(sd, SS_KUNAIKAITEN) * 10) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SS_KUNAIKAITEN:
-			skillratio += -100 + 800 + (700 + pc_checkskill(sd, SS_KUNAIWAIKYOKU) * 70) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 550 + (900 + pc_checkskill(sd, SS_KUNAIWAIKYOKU) * 70) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SS_KAGEGISSEN:
-			skillratio += -100 + 1500 + (750 + pc_checkskill(sd, SS_KAGENOMAI) * 50) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 1000 + (1000 + pc_checkskill(sd, SS_KAGENOMAI) * 100) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			if (wd->miscflag & SKILL_ALTDMG_FLAG)
 				skillratio = skillratio * 3 / 10;
 			break;
 		case SKE_MIDNIGHT_KICK:
-			skillratio += -100 + 600 + (1200 + pc_checkskill(sd, SKE_SKY_MASTERY) * 5) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 800 + (1500 + pc_checkskill(sd, SKE_SKY_MASTERY) * 5) * skill_lv + 5 * sstatus->pow;
 			if (sc && (sc->getSCE(SC_MIDNIGHT_MOON) || sc->getSCE(SC_SKY_ENCHANT)))
 				skillratio += 950 + 250 * skill_lv;
 			RE_LVL_DMOD(100);
@@ -6258,7 +6258,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case SKE_DAWN_BREAK:
-			skillratio += -100 + 400 + (400 + pc_checkskill(sd, SKE_SKY_MASTERY) * 5) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 600 + (700 + pc_checkskill(sd, SKE_SKY_MASTERY) * 5) * skill_lv + 5 * sstatus->pow;
 			if (sc && (sc->getSCE(SC_DAWN_MOON) || sc->getSCE(SC_SKY_ENCHANT)))
 				skillratio += 200 * skill_lv;
 			RE_LVL_DMOD(100);
@@ -6280,7 +6280,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case HN_SPIRAL_PIERCE_MAX:
-			skillratio += -100 + 700 + (800 + pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 3) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 1000 + (1500 + pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 3) * skill_lv + 5 * sstatus->pow;
 			switch (status_get_size(target))
 			{
 				case 0: skillratio = skillratio * 15 / 10;  break;
@@ -6290,7 +6290,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case HN_SHIELD_CHAIN_RUSH:
-			skillratio += -100 + 700 + (500 + pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 3) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 1350 + (1000 + pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 3) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case HN_MEGA_SONIC_BLOW:
@@ -6300,7 +6300,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case HN_DOUBLEBOWLINGBASH:
-			skillratio += -100 + 200 + (300 + pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 3) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 250 + (400 + pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 3) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SH_HOWLING_OF_CHUL_HO:
@@ -6316,7 +6316,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case SH_CHUL_HO_SONIC_CLAW:
-			skillratio += -100 + 850 + 1650 * skill_lv + 50 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY) + 5 * sstatus->pow;
+			skillratio += -100 + 2500 + 2000 * skill_lv + 50 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY) + 5 * sstatus->pow;
 			if ((sd && pc_checkskill(sd, SH_COMMUNE_WITH_CHUL_HO)) || (sc && sc->getSCE(SC_TEMPORARY_COMMUNION)))
 				skillratio += 400 * skill_lv + 50 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY);
 			RE_LVL_DMOD(100);
@@ -8038,15 +8038,15 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case SS_SEKIENHOU:
-						skillratio += -100 + 500 + (1000 + 70 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 600 + (1100 + 70 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case SS_REIKETSUHOU:
-						skillratio += -100 + 350 + (850 + 40 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 450 + (950 + 40 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case SS_KINRYUUHOU:
-						skillratio += -100 + 450 + (950 + 15 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 800 + (1500 + 15 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case SS_ANKOKURYUUAKUMU:
@@ -8054,7 +8054,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case SS_RAIDENPOU:
-						skillratio += -100 + 500 + (950 + 70 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 600 + (1100 + 70 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case SS_ANTENPOU:
@@ -8072,7 +8072,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case HN_HELLS_DRIVE:
-						skillratio += -100 + 1500 + (700 + 4 * pc_checkskill(sd, HN_SELFSTUDY_SOCERY)) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 1700 + (900 + 4 * pc_checkskill(sd, HN_SELFSTUDY_SOCERY)) * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case HN_GROUND_GRAVITATION:
@@ -8105,9 +8105,9 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case SH_HYUN_ROK_CANNON:
-						skillratio += -100 + 1050 + 1550 * skill_lv + 50 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY) + 5 * sstatus->spl;
+						skillratio += -100 + 1450 + 2000 * skill_lv + 50 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY) + 5 * sstatus->spl;
 						if ((sd && pc_checkskill(sd, SH_COMMUNE_WITH_HYUN_ROK)) || (sc && sc->getSCE(SC_TEMPORARY_COMMUNION)))
-							skillratio += 300 * skill_lv + 25 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY);
+							skillratio += 400 * skill_lv + 25 * pc_checkskill(sd, SH_MYSTICAL_CREATURE_MASTERY);
 						RE_LVL_DMOD(100);
 						break;
 					case SOA_EXORCISM_OF_MALICIOUS_SOUL:
@@ -8121,9 +8121,9 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case SOA_TALISMAN_OF_BLUE_DRAGON:
-						skillratio += -100 + 600 + (1700 + pc_checkskill(sd, SOA_TALISMAN_MASTERY) * 15) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 600 + (2300 + pc_checkskill(sd, SOA_TALISMAN_MASTERY) * 15) * skill_lv + 5 * sstatus->spl;
 						if (sc && sc->getSCE(SC_T_FIFTH_GOD) )
-							skillratio += 500 * skill_lv;
+							skillratio += 720 * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case SOA_TALISMAN_OF_WHITE_TIGER:
@@ -8133,7 +8133,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case SOA_TALISMAN_OF_RED_PHOENIX:
-						skillratio += -100 + 1200 + (1250 + pc_checkskill(sd, SOA_TALISMAN_MASTERY) * 15) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 2400 + (1250 + pc_checkskill(sd, SOA_TALISMAN_MASTERY) * 15) * skill_lv + 5 * sstatus->spl;
 						if (sc && sc->getSCE(SC_T_FIFTH_GOD))
 							skillratio += 200 + 400 * skill_lv;
 						RE_LVL_DMOD(100);
@@ -8583,7 +8583,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						}
 						break;
 					case AG_SOUL_VC_STRIKE:
-						skillratio += -100 + 250 * skill_lv + 15 * sstatus->spl;
+						skillratio += -100 + 300 * skill_lv + 15 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_STRANTUM_TREMOR:
@@ -8637,7 +8637,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_ROCK_DOWN:
-						skillratio += -100 + 1200 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 1550 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_CLIMAX ) ){
 							skillratio += 300 * skill_lv;
@@ -8646,7 +8646,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_STORM_CANNON:
-						skillratio += -100 + 1200 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 1550 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_CLIMAX ) ){
 							skillratio += 300 * skill_lv;
@@ -8655,15 +8655,15 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_CRIMSON_ARROW:
-						skillratio += -100 + 350 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 400 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_CRIMSON_ARROW_ATK:
-						skillratio += -100 + 700 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 750 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_FROZEN_SLASH:
-						skillratio += -100 + 400 + 900 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 200 + 1000 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_CLIMAX ) ){
 							skillratio += 150 + 350 * skill_lv;
@@ -8681,9 +8681,9 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						break;
 					case IG_CROSS_RAIN:
 						if( sc && sc->getSCE( SC_HOLY_S ) ){
-							skillratio += -100 + ( 450 + 15 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
+							skillratio += -100 + ( 650 + 15 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
 						}else{
-							skillratio += -100 + ( 320 + 10 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
+							skillratio += -100 + ( 450 + 10 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
 						}
 						skillratio += 7 * sstatus->spl;
 						RE_LVL_DMOD(100);
@@ -8708,9 +8708,9 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case CD_FRAMEN:
-						skillratio += -100 + (950 + 5 * pc_checkskill(sd,CD_FIDUS_ANIMUS)) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + (1300 + 5 * pc_checkskill(sd,CD_FIDUS_ANIMUS)) * skill_lv + 5 * sstatus->spl;
 						if (tstatus->race == RC_UNDEAD || tstatus->race == RC_DEMON)
-							skillratio += 100 * skill_lv;
+							skillratio += 50 * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_DESTRUCTIVE_HURRICANE_CLIMAX:// Is this affected by BaseLV and SPL too??? [Rytech]
@@ -8718,21 +8718,21 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case ABC_ABYSS_STRIKE:
-						skillratio += -100 + 2200 * skill_lv + 10 * sstatus->spl;
+						skillratio += -100 + 2650 * skill_lv + 10 * sstatus->spl;
 						if (tstatus->race == RC_DEMON || tstatus->race == RC_ANGEL)
-							skillratio += 150 * skill_lv;
+							skillratio += 200 * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case ABC_ABYSS_SQUARE:
-						skillratio += -100 + ( 570 + 20 * pc_checkskill( sd, ABC_MAGIC_SWORD_M ) ) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + ( 750 + 40 * pc_checkskill( sd, ABC_MAGIC_SWORD_M ) ) * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case TR_METALIC_FURY: {
 							int area = skill_get_splash(skill_id, skill_lv);
 							int count = map_forcountinarea(skill_check_bl_sc,target->m,target->x - area,target->y - area,target->x + area,target->y + area,5,BL_MOB,SC_SOUNDBLEND);
-							skillratio += -100 + (2600 + 300 * count) * skill_lv + 5 * sstatus->spl;
+							skillratio += -100 + (3850 + 300 * count) * skill_lv + 5 * sstatus->spl;
 							if (tsc && tsc->getSCE(SC_SOUNDBLEND))
-								skillratio += 1000 * skill_lv;
+								skillratio += 800 * skill_lv;
 							RE_LVL_DMOD(100);
 						}
 						break;
@@ -8747,52 +8747,52 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						}
 						break;
 					case EM_DIAMOND_STORM:
-						skillratio += -100 + 400 + 1550 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 500 + 2500 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_DILUVIO ) ){
-							skillratio += 5000 + 250 * skill_lv  + 5 * sstatus->spl;
+							skillratio += 5800 + 500 * skill_lv  + 5 * sstatus->spl;
 						}
 
 						RE_LVL_DMOD(100);
 						break;
 					case EM_LIGHTNING_LAND:
-						skillratio += -100 + 500 + 650 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 200 + 1200 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_PROCELLA ) ){
-							skillratio += 400 * skill_lv;
+							skillratio += 200 * skill_lv;
 						}
 
 						RE_LVL_DMOD(100);
 						break;
 					case EM_VENOM_SWAMP:
-						skillratio += -100 + 500 + 650 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 200 + 1200 * skill_lv + 5 * sstatus->spl;
 
 						if( sc && sc->getSCE( SC_SUMMON_ELEMENTAL_SERPENS ) ){
-							skillratio += 400 * skill_lv;
+							skillratio += 200 * skill_lv;
 						}
 
 						RE_LVL_DMOD(100);
 						break;
 					case EM_CONFLAGRATION:
-						skillratio += -100 + 500 + 650 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 200 + 1200 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_ARDOR ) ){
-							skillratio += 400 * skill_lv;
+							skillratio += 200 * skill_lv;
 						}
 
 						RE_LVL_DMOD(100);
 						break;
 					case EM_TERRA_DRIVE:
-						skillratio += -100 + 400 + 1550 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 500 + 2100 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_SUMMON_ELEMENTAL_TERREMOTUS ) ){
-							skillratio += 5000 + 250 * skill_lv + 5 * sstatus->spl;
+							skillratio += 5800 + 500 * skill_lv + 5 * sstatus->spl;
 						}
 
 						RE_LVL_DMOD(100);
 						break;
 					case ABC_FROM_THE_ABYSS_ATK:
-						skillratio += -100 + 100 + 500 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 400 + 600 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case EM_ELEMENTAL_BUSTER_FIRE:
@@ -8800,7 +8800,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 					case EM_ELEMENTAL_BUSTER_WIND:
 					case EM_ELEMENTAL_BUSTER_GROUND:
 					case EM_ELEMENTAL_BUSTER_POISON:
-						skillratio += -100 + 500 + 2200 * skill_lv + 10 * sstatus->spl;
+						skillratio += -100 + 50 + 2700 * skill_lv + 10 * sstatus->spl;
 						if (tstatus->race == RC_FORMLESS || tstatus->race == RC_DRAGON)
 							skillratio += 150 * skill_lv;
 						RE_LVL_DMOD(100);

--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -1911,11 +1911,11 @@ int64 battle_calc_damage(struct block_list *src,struct block_list *bl,struct Dam
 			switch (skill_id) {
 			case HN_SHIELD_CHAIN_RUSH:
 			case HN_DOUBLEBOWLINGBASH:
-				damage += damage / 2; 
+				damage += damage * 70 / 100; 
 				break;
 			case HN_MEGA_SONIC_BLOW:
 			case HN_SPIRAL_PIERCE_MAX:
-				damage += damage * 7 / 10;
+				damage += damage;
 				break;
 			}
 		}
@@ -4252,8 +4252,8 @@ static void battle_calc_skill_base_damage(struct Damage* wd, struct block_list *
 				}
 #else
 				if ((skill = pc_checkskill(sd, TK_POWER)) > 0) {
-					ATK_ADDRATE(wd->damage, wd->damage2, 10 + 15 * skill);
-					RE_ALLATK_ADDRATE(wd, 10 + 15 * skill);
+					ATK_ADDRATE(wd->damage, wd->damage2, 10 + 18 * skill);
+					RE_ALLATK_ADDRATE(wd, 10 + 18 * skill);
 				}
 #endif
 			}
@@ -4414,7 +4414,7 @@ static void battle_calc_multi_attack(struct Damage* wd, struct block_list *src,s
 			break;
 		case NW_THE_VIGILANTE_AT_NIGHT:
 			if (sd && sd->weapontype1 == W_GATLING)
-				wd->div_ += 3;
+				wd->div_ += 2;
 			break;
 #ifdef RENEWAL
 		case AS_POISONREACT:
@@ -5756,7 +5756,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			break;
 		case DK_HACKANDSLASHER:
 		case DK_HACKANDSLASHER_ATK:
-			skillratio += -100 + 300 + 700 * skill_lv;
+			skillratio += -100 + 200 + 750 * skill_lv;
 			skillratio += 7 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
@@ -5767,7 +5767,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case DK_MADNESS_CRUSHER:
-			skillratio += -100 + 400 + 800 * skill_lv + 7 * sstatus->pow;
+			skillratio += -100 + 350 + 1600 * skill_lv + 10 * sstatus->pow;
 			if( sd != nullptr ){
 				int16 index = sd->equip_index[EQI_HAND_R];
 
@@ -5780,9 +5780,9 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio *= 2;
 			break;
 		case DK_STORMSLASH:
-			skillratio += -100 + 100 + 170 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 200 + 400 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
-			if (sc && sc->getSCE(SC_GIANTGROWTH) && rnd()%100 < 30)
+			if (sc && sc->getSCE(SC_GIANTGROWTH) && rnd()%100 < 60)
 				skillratio *= 2;
 			break;
 		case DK_DRAGONIC_BREATH:
@@ -5798,16 +5798,16 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_MASSIVE_F_BLASTER:
-			skillratio += -100 + 2150 * skill_lv + 15 * sstatus->pow;
+			skillratio += -100 + 2300 * skill_lv + 15 * sstatus->pow;
 			if (tstatus->race == RC_BRUTE || tstatus->race == RC_DEMON)
 				skillratio += 150 * skill_lv;
 			RE_LVL_DMOD(100);
 			break;
 		case IQ_EXPOSION_BLASTER:
-			skillratio += -100 + 2800 * skill_lv + 15 * sstatus->pow;
+			skillratio += -100 + 2400 * skill_lv + 10 * sstatus->pow;
 
 			if( tsc != nullptr && tsc->getSCE( SC_HOLY_OIL ) ){
-				skillratio += 400 * skill_lv;
+				skillratio += 350 + 1050 * skill_lv + 5 * sstatus->pow;
 			}
 
 			RE_LVL_DMOD(100);
@@ -5850,7 +5850,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 				skillratio += skillratio * i / 100;
 			break;
 		case IG_SHIELD_SHOOTING:
-			skillratio += -100 + 750 + 2850 * skill_lv + 7 * sstatus->pow;
+			skillratio += -100 + 650 + 2850 * skill_lv + 7 * sstatus->pow;
 			skillratio += skill_lv * 50 * pc_checkskill( sd, IG_SHIELD_MASTERY );
 			if (sd) { // Damage affected by the shield's weight and refine. Need official formula. [Rytech]
 				short index = sd->equip_index[EQI_HAND_L];
@@ -5863,7 +5863,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case IG_OVERSLASH:
-			skillratio += -100 + (120 + pc_checkskill(sd, IG_SPEAR_SWORD_M) * 10) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + (160 + pc_checkskill(sd, IG_SPEAR_SWORD_M) * 25) * skill_lv + 7 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			if ((i = pc_checkskill_imperial_guard(sd, 3)) > 0)
 				skillratio += skillratio * i / 100;
@@ -5878,7 +5878,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case CD_PETITIO:
-			skillratio += -100 + (1050 + pc_checkskill(sd,CD_MACE_BOOK_M) * 10) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + (1050 + pc_checkskill(sd,CD_MACE_BOOK_M) * 50) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_DANCING_KNIFE:
@@ -5904,7 +5904,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_SHADOW_STAB:
-			skillratio += -100 + 300 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 400 * skill_lv + 7 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SHC_IMPACT_CRATER:
@@ -5918,7 +5918,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case MT_AXE_STOMP:
-			skillratio += -100 + 350 + 850 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 400 + 950 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case MT_MIGHTY_SMASH:
@@ -5951,7 +5951,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_ABYSS_DAGGER:
-			skillratio += -100 + 100 + 500 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 100 + 900 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_UNLUCKY_RUSH:
@@ -5967,11 +5967,11 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_DEFT_STAB:
-			skillratio += -100 + 350 + 550 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 250 + 350 * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case ABC_FRENZY_SHOT:
-			skillratio += -100 + 400 * skill_lv + 5 * sstatus->con;
+			skillratio += -100 + 150 + 600 * skill_lv + 15 * sstatus->con;
 			RE_LVL_DMOD(100);
 			break;
 		case WH_HAWKRUSH:
@@ -5985,13 +5985,13 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case WH_GALESTORM:
-			skillratio += -100 + 950 * skill_lv + 10 * sstatus->con;
+			skillratio += -100 + 1000 * skill_lv + 10 * sstatus->con;
 			RE_LVL_DMOD(100);
 			if (sc && sc->getSCE(SC_CALAMITYGALE) && (tstatus->race == RC_BRUTE || tstatus->race == RC_FISH))
 				skillratio += skillratio * 50 / 100;
 			break;
 		case WH_CRESCIVE_BOLT:
-			skillratio += -100 + 340 * skill_lv + 5 * sstatus->con;
+			skillratio += -100 + 400 + 900 * skill_lv + 5 * sstatus->con;
 			RE_LVL_DMOD(100);
 			if (sc) {
 				if (sc->getSCE(SC_CRESCIVEBOLT))
@@ -6094,13 +6094,13 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			}
 			break;
 		case TR_RHYTHMSHOOTING:
-			skillratio += -100 + 200 + 120 * skill_lv;
+			skillratio += -100 + 450 + 650 * skill_lv;
 
 			if (sd && pc_checkskill(sd, TR_STAGE_MANNER) > 0)
-				skillratio += 3 * sstatus->con;
+				skillratio += 5 * sstatus->con;
 
 			if (tsc && tsc->getSCE(SC_SOUNDBLEND))
-				skillratio += 100 + 100 * skill_lv;
+				skillratio += 350 + 100 * skill_lv + 2 * sstatus->con;
 
 			RE_LVL_DMOD(100);
 			if (sc && sc->getSCE(SC_MYSTIC_SYMPHONY)) {
@@ -6118,11 +6118,11 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			skillratio += -100 + 50000;
 			break;
 		case NW_HASTY_FIRE_IN_THE_HOLE:
-			skillratio += -100 + 1500 + 1050 * skill_lv + 20 * pc_checkskill(sd, NW_GRENADE_MASTERY) + 5 * sstatus->con;
+			skillratio += -100 + 1500 + 1500 * skill_lv + 20 * pc_checkskill(sd, NW_GRENADE_MASTERY) + 5 * sstatus->con;
 			RE_LVL_DMOD(100);
 			break;
 		case NW_BASIC_GRENADE:
-			skillratio += -100 + 1000 + 950 * skill_lv + 50 * pc_checkskill(sd, NW_GRENADE_MASTERY) + 5 * sstatus->con;
+			skillratio += -100 + 1500 + 2100 * skill_lv + 50 * pc_checkskill(sd, NW_GRENADE_MASTERY) + 5 * sstatus->con;
 			RE_LVL_DMOD(100);
 			break;
 		case NW_GRENADES_DROPPING:
@@ -6130,35 +6130,35 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case NW_WILD_FIRE:
-			skillratio += -100 + 1000 + 2300 * skill_lv + 5 * sstatus->con;
+			skillratio += -100 + 1500 + 3000 * skill_lv + 5 * sstatus->con;
 			if (sc && sc->getSCE(SC_INTENSIVE_AIM_COUNT))
 				skillratio += sc->getSCE(SC_INTENSIVE_AIM_COUNT)->val1 * 500 * skill_lv;
 			if (sd && sd->weapontype1 == W_SHOTGUN)
-				skillratio += 150 * skill_lv;
+				skillratio += 200 * skill_lv;
 			RE_LVL_DMOD(100);
 			break;
 		case NW_MAGAZINE_FOR_ONE:
-			skillratio += -100 + 100 + 450 * (skill_lv-1) + 5 * sstatus->con;
+			skillratio += -100 + 250 + 500 * skill_lv + 5 * sstatus->con;
 			if (sc && sc->getSCE(SC_INTENSIVE_AIM_COUNT))
 				skillratio += sc->getSCE(SC_INTENSIVE_AIM_COUNT)->val1 * 100 * skill_lv;
 			if (sd && sd->weapontype1 == W_REVOLVER)
-				skillratio += 50 + 100 * (skill_lv-1);
+				skillratio += 50 + 300 * skill_lv;
 			RE_LVL_DMOD(100);
 			break;
 		case NW_SPIRAL_SHOOTING:
-			skillratio += -100 + 1000 + 1500 * skill_lv + 5 * sstatus->con;
+			skillratio += -100 + 1200 + 1700 * skill_lv + 5 * sstatus->con;
 			if (sc && sc->getSCE(SC_INTENSIVE_AIM_COUNT))
 				skillratio += sc->getSCE(SC_INTENSIVE_AIM_COUNT)->val1 * 150 * skill_lv;
 			if (sd && sd->weapontype1 == W_RIFLE) 
-				skillratio += 200 + 200 * skill_lv;
+				skillratio += 200 + 1100 * skill_lv;
 			RE_LVL_DMOD(100);
 			break;
 		case NW_ONLY_ONE_BULLET:
-			skillratio += -100 + 800 + 1350 * skill_lv + 5 * sstatus->con;
+			skillratio += -100 + 1200 + 3000 * skill_lv + 5 * sstatus->con;
 			if (sc && sc->getSCE(SC_INTENSIVE_AIM_COUNT))
 				skillratio += sc->getSCE(SC_INTENSIVE_AIM_COUNT)->val1 * 350 * skill_lv;
 			if (sd && sd->weapontype1 == W_REVOLVER) {
-				skillratio += 150 * skill_lv;
+				skillratio += 400 * skill_lv;
 			}
 			RE_LVL_DMOD(100);
 			break;
@@ -6186,7 +6186,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case SS_KAGEGARI:
-			skillratio += -100 + 500 + (400 + pc_checkskill(sd, SS_KAGEGISSEN) * 5) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 600 + (900 + pc_checkskill(sd, SS_KAGEGISSEN) * 5) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SS_KAGEAKUMU:
@@ -6197,21 +6197,21 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case SS_KAGENOMAI:
-			skillratio += -100 + 400 + (550 + pc_checkskill(sd, SS_KAGEGARI) * 50) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 550 + (750 + pc_checkskill(sd, SS_KAGEGARI) * 50) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			if (wd->miscflag & SKILL_ALTDMG_FLAG)
 				skillratio = skillratio * 3 / 10;
 			break;
 		case SS_FUUMASHOUAKU:
-			skillratio += -100 + 700 + (200 + pc_checkskill(sd, SS_FUUMAKOUCHIKU) * 5) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 850 + (350 + pc_checkskill(sd, SS_FUUMAKOUCHIKU) * 5) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SS_FUUMAKOUCHIKU:
-			skillratio += -100 + 600 + (400 + pc_checkskill(sd, SS_FUUMASHOUAKU) * 30) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 600 + (1200 + pc_checkskill(sd, SS_FUUMASHOUAKU) * 30) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SS_FUUMAKOUCHIKU_BLASTING:
-			skillratio += -100 + 800 + (600 + pc_checkskill(sd, SS_FUUMASHOUAKU) * 30) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 600 + (1500 + pc_checkskill(sd, SS_FUUMASHOUAKU) * 30) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SS_KUNAIWAIKYOKU:
@@ -6229,7 +6229,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case SS_KAGEGISSEN:
-			skillratio += -100 + 1600 + (700 + pc_checkskill(sd, SS_KAGENOMAI) * 100) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 1500 + (750 + pc_checkskill(sd, SS_KAGENOMAI) * 50) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			if (wd->miscflag & SKILL_ALTDMG_FLAG)
 				skillratio = skillratio * 3 / 10;
@@ -6241,16 +6241,16 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case SKE_ALL_IN_THE_SKY:
-			skillratio += -100 + 3000 + 2000 * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 250 + 1200 * skill_lv + 5 * sstatus->pow;
 			if (status_get_race(target) == RC_DEMIHUMAN || status_get_race(target) == RC_DEMON)
 				wd->div_ = 3;
 			break;
 		case SKE_TWINKLING_GALAXY:
-			skillratio += -100 + 200 + (400 + pc_checkskill(sd, SKE_SKY_MASTERY) * 3) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 300 + (500 + pc_checkskill(sd, SKE_SKY_MASTERY) * 3) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SKE_STAR_CANNON:
-			skillratio += -100 + 200 + (500 + pc_checkskill(sd, SKE_SKY_MASTERY) * 5) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 250 + (550 + pc_checkskill(sd, SKE_SKY_MASTERY) * 5) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SKE_STAR_BURST:
@@ -6280,7 +6280,7 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case HN_SPIRAL_PIERCE_MAX:
-			skillratio += -100 + 550 + (350 + pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 3) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 700 + (800 + pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 3) * skill_lv + 5 * sstatus->pow;
 			switch (status_get_size(target))
 			{
 				case 0: skillratio = skillratio * 15 / 10;  break;
@@ -6290,17 +6290,17 @@ static int battle_calc_attack_skill_ratio(struct Damage* wd, struct block_list *
 			RE_LVL_DMOD(100);
 			break;
 		case HN_SHIELD_CHAIN_RUSH:
-			skillratio += -100 + 600 + (450 + pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 3) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 700 + (500 + pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 3) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case HN_MEGA_SONIC_BLOW:
-			skillratio += -100 + 900 + (450 + pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 5) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 900 + (750 + pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 5) * skill_lv + 5 * sstatus->pow;
 			if (status_get_hp(target) < status_get_max_hp(target) / 2)
 				skillratio *= 2;
 			RE_LVL_DMOD(100);
 			break;
 		case HN_DOUBLEBOWLINGBASH:
-			skillratio += -100 + 150 + (250 + pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 3) * skill_lv + 5 * sstatus->pow;
+			skillratio += -100 + 200 + (300 + pc_checkskill(sd, HN_SELFSTUDY_TATICS) * 3) * skill_lv + 5 * sstatus->pow;
 			RE_LVL_DMOD(100);
 			break;
 		case SH_HOWLING_OF_CHUL_HO:
@@ -7251,7 +7251,7 @@ static struct Damage initialize_weapon_data(struct block_list *src, struct block
 				break;
 			case SHC_SHADOW_STAB:
 				if (wd.miscflag == 2)
-					wd.div_ = 2;
+					wd.div_ = 3;
 				break;
 			case SHC_IMPACT_CRATER:
 				if (sc && sc->getSCE(SC_ROLLINGCUTTER))
@@ -8038,15 +8038,15 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case SS_SEKIENHOU:
-						skillratio += -100 + 850 + (1250 + 70 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 500 + (1000 + 70 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case SS_REIKETSUHOU:
-						skillratio += -100 + 250 + (550 + 40 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 350 + (850 + 40 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case SS_KINRYUUHOU:
-						skillratio += -100 + 300 + (400 + 15 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 450 + (950 + 15 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case SS_ANKOKURYUUAKUMU:
@@ -8054,7 +8054,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case SS_RAIDENPOU:
-						skillratio += -100 + 600 + (1300 + 70 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 500 + (950 + 70 * pc_checkskill(sd, SS_ANTENPOU)) * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case SS_ANTENPOU:
@@ -8121,27 +8121,27 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case SOA_TALISMAN_OF_BLUE_DRAGON:
-						skillratio += -100 + 250 + (1450 + pc_checkskill(sd, SOA_TALISMAN_MASTERY) * 15) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 600 + (1700 + pc_checkskill(sd, SOA_TALISMAN_MASTERY) * 15) * skill_lv + 5 * sstatus->spl;
 						if (sc && sc->getSCE(SC_T_FIFTH_GOD) )
-							skillratio += 100 + 200 * skill_lv;
+							skillratio += 500 * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case SOA_TALISMAN_OF_WHITE_TIGER:
-						skillratio += -100 + 350 + (950 + pc_checkskill(sd, SOA_TALISMAN_MASTERY) * 15) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 400 + (1000 + pc_checkskill(sd, SOA_TALISMAN_MASTERY) * 15) * skill_lv + 5 * sstatus->spl;
 						if (sc && sc->getSCE(SC_T_FIFTH_GOD))
 							skillratio += 400 * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case SOA_TALISMAN_OF_RED_PHOENIX:
-						skillratio += -100 + 1000 + (900 + pc_checkskill(sd, SOA_TALISMAN_MASTERY) * 15) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 1200 + (1250 + pc_checkskill(sd, SOA_TALISMAN_MASTERY) * 15) * skill_lv + 5 * sstatus->spl;
 						if (sc && sc->getSCE(SC_T_FIFTH_GOD))
 							skillratio += 200 + 400 * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case SOA_TALISMAN_OF_BLACK_TORTOISE:
-						skillratio += -100 + 2150 + (1450 + pc_checkskill(sd, SOA_TALISMAN_MASTERY) * 15) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 2150 + (1600 + pc_checkskill(sd, SOA_TALISMAN_MASTERY) * 15) * skill_lv + 5 * sstatus->spl;
 						if (sc && sc->getSCE(SC_T_FIFTH_GOD))
-							skillratio += 150 + 400 * skill_lv;
+							skillratio += 150 + 500 * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case SOA_CIRCLE_OF_DIRECTIONS_AND_ELEMENTALS:
@@ -8554,14 +8554,14 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_DESTRUCTIVE_HURRICANE:
-						skillratio += -100 + 250 + 2800 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 600 + 2850 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						if (sc && sc->getSCE(SC_CLIMAX))
 						{
 							if (sc->getSCE(SC_CLIMAX)->val1 == 3)
-								skillratio *= 3;
+								skillratio += skillratio * 150 / 100;
 							else if (sc->getSCE(SC_CLIMAX)->val1 == 5)
-								skillratio += skillratio * 50 / 100;
+								skillratio += skillratio * 30 / 100;
 						}
 						break;
 					case AG_RAIN_OF_CRYSTAL:
@@ -8637,7 +8637,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_ROCK_DOWN:
-						skillratio += -100 + 950 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 1200 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_CLIMAX ) ){
 							skillratio += 300 * skill_lv;
@@ -8646,7 +8646,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_STORM_CANNON:
-						skillratio += -100 + 950 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 1200 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_CLIMAX ) ){
 							skillratio += 300 * skill_lv;
@@ -8655,15 +8655,15 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case AG_CRIMSON_ARROW:
-						skillratio += -100 + 300 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 350 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_CRIMSON_ARROW_ATK:
-						skillratio += -100 + 600 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 700 * skill_lv + 5 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case AG_FROZEN_SLASH:
-						skillratio += -100 + 250 + 900 * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + 400 + 900 * skill_lv + 5 * sstatus->spl;
 
 						if( sc != nullptr && sc->getSCE( SC_CLIMAX ) ){
 							skillratio += 150 + 350 * skill_lv;
@@ -8681,11 +8681,11 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						break;
 					case IG_CROSS_RAIN:
 						if( sc && sc->getSCE( SC_HOLY_S ) ){
-							skillratio += -100 + ( 450 + 10 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
+							skillratio += -100 + ( 450 + 15 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
 						}else{
-							skillratio += -100 + ( 320 + 5 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
+							skillratio += -100 + ( 320 + 10 * pc_checkskill( sd, IG_SPEAR_SWORD_M ) ) * skill_lv;
 						}
-						skillratio += 5 * sstatus->spl;
+						skillratio += 7 * sstatus->spl;
 						RE_LVL_DMOD(100);
 						break;
 					case CD_ARBITRIUM:
@@ -8694,8 +8694,8 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case CD_ARBITRIUM_ATK:
-						skillratio += -100 + 1250 * skill_lv + 7 * sstatus->spl;
-						skillratio += 10 * pc_checkskill( sd, CD_FIDUS_ANIMUS ) * skill_lv;
+						skillratio += -100 + 1750 * skill_lv + 10 * sstatus->spl;
+						skillratio += 50 * pc_checkskill( sd, CD_FIDUS_ANIMUS ) * skill_lv;
 						RE_LVL_DMOD(100);
 						break;
 					case CD_PNEUMATICUS_PROCELLA:
@@ -8708,7 +8708,7 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 						RE_LVL_DMOD(100);
 						break;
 					case CD_FRAMEN:
-						skillratio += -100 + (800 + 5 * pc_checkskill(sd,CD_FIDUS_ANIMUS)) * skill_lv + 5 * sstatus->spl;
+						skillratio += -100 + (950 + 5 * pc_checkskill(sd,CD_FIDUS_ANIMUS)) * skill_lv + 5 * sstatus->spl;
 						if (tstatus->race == RC_UNDEAD || tstatus->race == RC_DEMON)
 							skillratio += 100 * skill_lv;
 						RE_LVL_DMOD(100);
@@ -8730,7 +8730,9 @@ struct Damage battle_calc_magic_attack(struct block_list *src,struct block_list 
 					case TR_METALIC_FURY: {
 							int area = skill_get_splash(skill_id, skill_lv);
 							int count = map_forcountinarea(skill_check_bl_sc,target->m,target->x - area,target->y - area,target->x + area,target->y + area,5,BL_MOB,SC_SOUNDBLEND);
-							skillratio += -100 + (2200 + 300 * count) * skill_lv + 5 * sstatus->spl;
+							skillratio += -100 + (2600 + 300 * count) * skill_lv + 5 * sstatus->spl;
+							if (tsc && tsc->getSCE(SC_SOUNDBLEND))
+								skillratio += 1000 * skill_lv;
 							RE_LVL_DMOD(100);
 						}
 						break;

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -3478,7 +3478,7 @@ int skill_mirage_cast(struct block_list* src, struct block_list* bl, int skill_i
 				map_foreachinrange(skill_area_sub, &itsu->unit->bl, skill_get_splash(skill_id, skill_lv), BL_CHAR,
 					src, skill_id, skill_lv, tick, BCT_ENEMY | SD_SPLASH | SD_ANIMATION | SKILL_ALTDMG_FLAG | 1, skill_castend_damage_id);
 				break;
-			case SS_KAGEGISSEN://damage splash
+			/*case SS_KAGEGISSEN://damage splash
 				x = bl->x;
 				y = bl->y;
 				skill_area_temp[1] = 0;
@@ -3493,7 +3493,7 @@ int skill_mirage_cast(struct block_list* src, struct block_list* bl, int skill_i
 						skill_get_splash(skill_id, skill_lv), skill_get_maxcount(skill_id, skill_lv), splash_target(src),
 						skill_get_type(skill_id), src, src, skill_id, skill_lv, tick, SKILL_ALTDMG_FLAG, BCT_ENEMY);
 				}
-				break;
+				break;*/
 			}
 		}
 	}
@@ -4625,7 +4625,7 @@ int64 skill_attack (int attack_type, struct block_list* src, struct block_list *
 					skill_addtimerskill(src, tick + dmg.amotion + skill_get_delay(skill_id, skill_lv), bl->id, 0, 0, skill_id, skill_lv, attack_type, flag|2);
 				break;
 			case ABC_DEFT_STAB:
-				if (skill_area_temp[1] == bl->id && rnd()%100 < 4 * skill_lv)// Need official autocast chance. [Rytech]
+				if (skill_area_temp[1] == bl->id && rnd()%100 < 0 * skill_lv)// Need official autocast chance. [Rytech]
 					skill_addtimerskill(src, tick + dmg.amotion, bl->id, 0, 0, skill_id, skill_lv, BF_WEAPON, 2);
 				break;
 		}
@@ -8815,7 +8815,7 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 				if (skill_id == AG_DESTRUCTIVE_HURRICANE)
 					splash_size = 9; // 19x19
 				else if(skill_id == AG_CRYSTAL_IMPACT)
-					splash_size = 14; // 29x29 - Entire screen.
+					splash_size = 7; // 15x15
 			}
 
 			skill_area_temp[1] = 0;
@@ -11843,9 +11843,9 @@ int skill_castend_nodamage_id (struct block_list *src, struct block_list *bl, ui
 		{
 			if (!(src == bl)) {
 				if ((sd && pc_checkskill(sd, SH_COMMUNE_WITH_KI_SUL)) || (sc && sc->getSCE(SC_TEMPORARY_COMMUNION)))
-					status_heal(bl, 0, 0, 6, 0);
+					status_heal(bl, 0, 0, 4, 0);
 				else
-					status_heal(bl, 0, 0, 3, 0);
+					status_heal(bl, 0, 0, 2, 0);
 			}
 		}
 		else

--- a/src/map/skill.cpp
+++ b/src/map/skill.cpp
@@ -2238,19 +2238,19 @@ int skill_additional_effect( struct block_list* src, struct block_list *bl, uint
 		*/
 		break;
 	case EM_DIAMOND_STORM:
-		sc_start(src, bl, SC_HANDICAPSTATE_FROSTBITE, 40 + 10 * skill_lv, skill_lv, skill_get_time2(skill_id, skill_lv));
+		sc_start(src, bl, SC_HANDICAPSTATE_FROSTBITE, 5, skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 	case EM_LIGHTNING_LAND:
-		sc_start(src, bl, SC_HANDICAPSTATE_LIGHTNINGSTRIKE, 10 + 10 * skill_lv, skill_lv, skill_get_time2(skill_id, skill_lv));
+		sc_start(src, bl, SC_HANDICAPSTATE_LIGHTNINGSTRIKE, 5, skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 	case EM_VENOM_SWAMP:
-		sc_start(src, bl, SC_HANDICAPSTATE_DEADLYPOISON, 10 + 10 * skill_lv, skill_lv, skill_get_time2(skill_id, skill_lv));
+		sc_start(src, bl, SC_HANDICAPSTATE_DEADLYPOISON, 5, skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 	case EM_CONFLAGRATION:
-		sc_start(src, bl, SC_HANDICAPSTATE_CONFLAGRATION, 10 + 10 * skill_lv, skill_lv, skill_get_time2(skill_id, skill_lv));
+		sc_start(src, bl, SC_HANDICAPSTATE_CONFLAGRATION, 5, skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 	case EM_TERRA_DRIVE:
-		sc_start(src, bl, SC_HANDICAPSTATE_CRYSTALLIZATION, 40 + 10 * skill_lv, skill_lv, skill_get_time2(skill_id, skill_lv));
+		sc_start(src, bl, SC_HANDICAPSTATE_CRYSTALLIZATION, 5, skill_lv, skill_get_time2(skill_id, skill_lv));
 		break;
 	case MT_RUSH_QUAKE:
 		sc_start( src, bl, SC_RUSH_QUAKE1, 100, skill_lv, skill_get_time( skill_id, skill_lv ) );

--- a/src/map/status.cpp
+++ b/src/map/status.cpp
@@ -13404,7 +13404,7 @@ int status_change_start(struct block_list* src, struct block_list* bl,enum sc_ty
 			tick = INFINITE_TICK;
 			break;
 		case SC_GUARDIAN_S:
-			val2 = ( status->max_hp / 2 ) * ( 50 * val1 ) / 100 + 15 * status->sta; // Barrier HP
+			val2 = ( status->max_hp * 30 / 100 ) * ( 25 * val1 ) / 100 + 15 * status->sta; // Barrier HP
 			break;
 		case SC_REBOUND_S:
 			val2 = 10 * val1;// Reduced Damage From Devotion


### PR DESCRIPTION
1. 盧恩龍爵 → 狂暴粉碎
：以 Lv5 為基準，SP 消耗自 68 減少至 55。
：以 Lv5 為基準，技能基礎倍率從 4400% 提升至 8350%。
：POW 的權重從 7 增加至 10。
→ 風暴斬擊
：技能獨立延遲自 0.3 秒增加至 0.35 秒。
：以 Lv5 為基準，SP 消耗自 60 減少至 55。
：以 Lv5 為基準，每刀技能基礎倍率自 950% 提升至 2200%。
：[巨人成長（1盧）]狀態下傷害增加機率從 30% 增加至 60%。
→ 橫揮斬
：以 Lv10 為基準，技能基礎倍率從 7300% 增加至 7700%。
：以 Lv10 為基準，攻撃範圍從 9×9 減少為 7×7。
：依施術者的爆擊率適用暴擊傷害。
2. 機甲神匠 → 戰斧踏滅
：以 Lv5 為基準，SP 消耗量從 74 增加至 85。
：以 Lv5 為基準，技能基礎倍率從 4600% 增加至 5150%。
→ 強力粉碎
：技能獨立延遲從 0.3 秒增加至 0.5 秒。
：增加了 0.25 秒的技能共通延遲。
：以 Lv10 為基準，SP 消耗量從 78 增加至 95。
：以 Lv10 為基準，技能基礎倍率從 3100%／3150% 降低至 1825%／1850%。(无改动) ：攻擊次數從 3／5 次攻擊增加至 5／7 次攻擊。（战斧踏灭下无改动）
：當存在戰斧踏滅效果時，POW 的權重從 7 增加至 10。（无改动）
→ 火花沖擊波
：技能獨立延遲從 0.7 秒減少至 0.5 秒。
：技能 10 級時，技能基礎倍率從 7750% 增加至 9250% 。
→ 三重雷射
：技能獨立延遲從 0.25 秒增加至 0.35 秒。
：增加了 0.25 秒的技能共通延遲。
：以 Lv5 為基準，技能基礎倍率從 3300%增加至 5050%。
：POW 的權重從 10 增加至 12。
3. 十字影武 → 野蠻衝擊
：技能獨立延遲從 1 秒減少至 0.7 秒。
：以 Lv10 為基準，攻擊範圍從 5×5 增加至 7×7 。
：增加了 AP 2恢復功能。
→ 暗影刺擊
：在[偽裝]或[偽裝強化]狀態下施放時，2 連擊效果變更為 2 次攻擊。
：[偽裝強化]狀態下施放時，變更為 3 次攻擊，傷害提升。（不会改 一刀切改成3连击）
：[偽裝強化]狀態下施放時，POW 的權重從 5 增加至 7。
：以 Lv5 為基準，技能基礎倍率從 1500% 增加至 1750%／2000%(偽裝強化) 。（不会改 一刀切改成2000）
4. 禁咒魔導士 → 冰晶飛瀑
：以 Lv5 為基準，攻擊範圍從 19×19 減少至 13×13。
：以 Lv5 為基準，SP 消耗量從 100 增加至 125。
→ 艷紅魔矢
：以 Lv5 為基準，SP 消耗量從 94 降低至 90。
：以 Lv5 為基準，技能直線基礎倍率從 1500% 增加至1750% 。
：以 Lv5 為基準，目標周圍的基礎爆炸傷害倍率從 3000% 增加至 3500% 。
→ 暴風加農砲
：以 Lv5 為基準，SP 消耗量從 94 降低至 88。
：以 Lv5 為基準，技能基礎倍率從 4750%/6250% 增加至 6000%/7500% 。
→ 巨石降臨
：以 Lv5 為基準，SP 消耗量從 94 降低至 88。
：以 Lv5 為基準，技能基礎倍率從 4750%／6250% 增加至 6000%／7500% 。
→ 冰刃斬擊
：以 Lv5 為基準，SP 消耗量從 96 增加至 115。
：以 Lv5 為基準，技能基礎倍率從 4750%／6650% 增加至 4900%／6800%。
→ 毀滅颶風
：技能獨立延遲從 2 秒增加至 2.5 秒。
：以 Lv5 為基準，技能基礎倍率從 14250% 增加至 14850%。
：依照[魔力巔峰]第 3 階段狀態下，傷害增加效果從 200% 減少至 150%。
：依照[魔力巔峰]第 5 階段狀態下，傷害增加效果從 50% 減少至 30%。
：以 Lv5 為基準，SP 消耗量從 132 增加至 186。
→ 水晶波爆
：以 Lv5 為基準，攻擊範圍從 15×15 減少至 13×13。
：依照[魔力巔峰]第 5 階段狀態下，攻擊範圍減少至 15×15。
：以 Lv5 為基準，SP消耗量從 132 增加至 152。
5. 樞機主教 → 聖靈鎮魂
：以 Lv5 為基準，技能基礎倍率從 4000%／4500% 增加至 4750%／5250% 。
→ 制裁謳歌
：技能獨立延遲從 1.5 秒減少至 1 秒。
：以 Lv10 為基準，SP 消耗量從 112 增加至 125。
：增加恢復 AP 2。
：以 Lv10 為基準，範圍攻擊的技能基礎倍率從12500%增加至 17500%。
：以 Lv10 為基準，範圍攻擊的[靈魂忠誠]習得 Lv 加成從 100 增加至 500。
：SPL 的範圍權重從 7 增加至 10。
→ 聖光打擊
：以 Lv10 為基準，攻擊範圍從 9×9 減少至 7×7 。
：以 Lv10 為基準，根據[鈍器&書籍精熟]習得 Lv 加成從 100 增加至 500。
6. 風鷹狩獵者 → 精英狙擊（遊俠）
：變更為不會被魔法效果解除和解除消除效果。
→ 憤怒暴風
：持續時間從 60 秒增加至 180 秒。
：技能獨立延遲從 300 秒減少至 180 秒。
：使用技能[精英狙擊]時，憤怒暴風的效果變更為不會取消。（未实装）
→ 毀滅風暴
：技能獨立延遲從 1.5 秒減少至 1.2 秒。
：以 Lv10 為基準，SP 消耗量從 100 增加至 120。
：以 Lv10 為基準，技能基礎倍率從 9500% 增加至 10000%。
：以 Lv10 為基準，攻擊範圍從 11×11 減少至 9×9 。
：CON 的權重從 5 增加至 10。
→ 漸進狙擊
：技能獨立延遲從 0.15 秒增加至 0.35 秒。
：技能共通後延遲從 0.3 秒增加至 0.7 秒。
：以 Lv10 為基準，技能基礎倍率從 3400% 增加至 9400% 。
7. 帝國聖衛軍 → 盾牌投擲
：以 Lv5 為基準，變更為對目標及其周圍 7×7 範圍內的目標造成遠距離物理傷害。
：以 Lv5 為基準，射程距離從 11 格減少至 9 格。
：以 Lv5 為基準，依[防盾精熟]習得 Lv 的加成值從 75 增加到 250。
：以 Lv5 為基準，技能基礎倍率從11900% 增加至14900% 。
：POW 的權重從 5 增加至 7。
：盾牌精煉值的權重從 4 增加至 25。
→ 瞬間斬擊
：以 Lv10 為基準，技能基礎倍率從1200% 增加至 1600% 。
：以 Lv10 為基準，根據[矛&劍精熟]習得 Lv 加成從 100 增加至 250。
：POW 的權重從 5 增加到 7。
→ 聖十字雨
：技能獨立延遲從 4.5 秒減少至 2.4 秒。
：以 Lv10 為基準，聖域持續時間從 4.5 秒減少至 2.4 秒。
：以 Lv10 為基準，依[矛&劍精熟]習得 Lv 的加成值從 50/100(抗性聖盾狀態) 增加到 100/150(抗性聖盾狀態)。 ：SPL 的權重從 5 增加到 7。
：AP恢復從 7 減少至 4。
8. 生命締造者 → 混亂荊棘
：當存在研究報告效果時，攻擊次數從 5 減少至 4 次。（无改动）
：以 Lv10 為基準，技能基礎倍率從 2700%／3250%(研究報告) 增加至 3200%／3350%(研究報告)。（无改动） → 炸藥粉
：以 Lv5 為基準，SP 消耗量從 74 增加到 97。
：以 Lv5 為基準，技能基礎倍率從 2650%／3150%(研究報告) 增加至 3150%／3650%(研究報告)。（无改动）
9. 深淵追踪者 → 深淵匕首
：以 Lv5 為基準，技能獨立延遲從 0.3秒 增加至 0.4秒。
：以 Lv5 為基準，SP 消耗量從 64 增加至 76。
：以 Lv5 為基準，技能基礎倍率從 2600％增加至 4600％。
→ 靈巧刺擊
：移除一定機率再次發動的效果。
：以 Lv10 為基準，SP 消耗量從 62 增加到 72。
：技能獨立延遲從 0.3 秒增加至 0.7 秒。
：以 Lv10 為基準，技能基礎倍率從 5850% 降低至 3750%。
：將 1 次攻擊分為 5 連擊的部分變更為 5 次攻擊。
→ 狂暴射擊
：技能獨立延遲從 0.2 秒增加至 0.35 秒。
：以 Lv10 為基準，SP 消耗量從 55 增加至 65。
：基本攻擊次數從 1 次增加至 2 次。
：以 Lv10 為基準，技能基礎倍率從 4000% 增加至 6150% 。
：CON 的權重從 5 增加至 15。
10. 聖裁者 → 聖油洗禮
：技能獨立延遲從 2 秒減少至 1.5 秒。
：移除消耗 1 瓶聖水的需求。
：以 Lv5 為基準，攻擊範圍從 11×11 減少至 9×9 。
→ 爆破衝擊
：增加技能共通延遲 1 秒。
：以 Lv5 為基準，SP 消耗量從 90 增加至 125。
：以 Lv5 為基準，攻擊範圍從 11×11 減少至 9×9 。
：以 Lv5 為基準，技能基礎倍率從14000% 降低至 12000% 。
：以 Lv5 為基準，[聖油洗禮]效果目標的技能基礎倍率從16000% 增加至17600%。
：POW 對無[聖油洗禮]效果目標的權重從 15 降低至 10。
→ 焰魔散彈
：增加技能共通延遲 0.5 秒。
：攻擊範圍從 11×11 減少至 9×9 。
：以 Lv10 為基準，技能基礎倍率從 21500%／23000% 增加至 23000%／24500%。
11. 天籟頌者＆樂之舞靈 → 節奏射擊
：技能獨立延遲從 0.15 秒增加至 0.35 秒。
：以 Lv5 為基準，技能基礎倍率從 800%／1400% 增加至 3700%／4550% 。
：CON 的權重從 3 增加至 5（[混聲烙印]的目標為 7）。
→ 金屬狂怒
：變更為對目標及其周圍內的敵人造成魔法傷害(以 Lv5 為基準，攻擊範圍 9×9 )。
：技能獨立延遲從 0.3 秒增加至 0.4 秒。
：技能共通延遲從 0.3 秒增加至 0.5 秒。
：變更為無法消除賦予的[混聲烙印]。
：以 Lv5 為基準，技能基礎倍率從 11000% 增加至 13000%／18000% （[混聲烙印]的目標）。 ：根據[混聲烙印]的目標，SPL 的權重從[1.5×混聲烙印習得Lv]增加至[2×混聲烙印習得Lv]。(未实装 不会改)
12. 夜巡者 → 夜間警戒者
：以 Lv5 為基準，SP消耗量從 65 增加至 88。
：以 Lv5 為基準，格林機槍的攻擊範圍從 13×13 減少至 11×11 。
→ 獨一槍彈
：技能獨立延遲從 0.3 秒增加至 0.35 秒。
：以 Lv5 為基準，技能基礎倍率從 7550%／8300% 增加至 16200%／18200%。
→ 螺旋射擊
：以 Lv5 為基準，技能基礎倍率從 8500%／9700% 增加至 9700%／15400%。
→ 彈匣盡空
：以 Lv5 為基準，技能基礎倍率從 1950%／2400% 增加至 2750%／4300%。
→ 廣域火力
：以 Lv5 為基準，技能基礎倍率從 13250%／12500% 增加至17500%／16500%。 → 基本榴彈
：以 Lv5 為基準，技能基礎倍率從 5750% 增加至 12000% 。
→ 急速轟炸
：以 Lv5 為基準，技能基礎倍率從 6750% 增加至 9000%。
13. 神鬼狼＆不知火 → 影狩刃
：以 Lv10 為基準，技能基礎倍率從 4500%提升至 9600%。
→ 影之舞
：技能獨立延遲從 0.5 秒減少至 0.4 秒。
：以 Lv10 為基準，SP 消耗量從 65 增加至 82。
：以 Lv10 為基準，技能範圍從 9×9 減少至 7×7 。
：以 Lv10 為基準，技能基礎倍率從 5900% 增加至 8050% 。
→ 影子一閃擊
：指定方向傷害技能變更為對目標及其周圍造成近距離物理傷害。
：以 Lv10 為基準，技能攻擊範圍為 7×7 。
：依施術者的爆擊率適用暴擊傷害。
：影分身變更為不會一同施展影一閃。
：技能射程距離從 1 格增加至 2 格。
：以 Lv10 為基準，技能基礎倍率從 8600% 增加至 9000% 。
：以 Lv10 為基準，依照[影之舞]習得 Lv 加成從 1000 減少至 500。
→ 風魔飛鏢-掌握
：以 Lv10 為基準，技能基礎倍率從 2700% 增加至 4350%。
→ 風魔飛鏢-構築
：指定方向傷害技能變更為對目標及其周圍造成 9×9 遠距離物理傷害。
：技能射程距離從 1 格增加至 9 格。
：以 Lv10 為基準，技能基礎倍率從 4600%／6800%(爆炸)增加至 12600%／15600%(爆炸)。 → 赤炎砲
：指定方向傷害技能變更為對目標及其周圍造成火屬性魔法傷害。
：以 Lv10 為基準，技能攻擊範圍為 7×7 。
：技能射程距離從 1 格增加至 9 格。
：以 Lv10 為基準，SP消耗量從 92 降低至 80。
：以 Lv10 為基準，技能基礎倍率從 13350% 減少至 10500%。
→ 冷血砲
：以 Lv10 為基準，SP 消耗量從 92 減少至 76。
：以 Lv10 為基準，技能基礎倍率從 5750% 增加至 8850% 。
→ 雷電砲
：指定方向傷害技能變更為對目標及其周圍造成風屬性魔法傷害。
：以 Lv10 為基準，技能攻擊範圍為 7×7 。
：技能射程距離從 1 格增加至 9 格。
：以 Lv10 為基準，SP消耗量從 92 降低至 80。
：以 Lv10 為基準，技能基礎倍率從 13600% 減少至 10000%。
→ 金龍砲
：從對目標到目標的直線範圍攻擊變更為對目標及其周圍內的敵人造成地屬性魔法傷害。
：以 Lv10 為基準，技能攻擊範圍為 5×5 。
：技能射程距離從 13 格減少至 9 格。
：以 Lv10 為基準，SP消耗量從 88 降低至 65。
：以 Lv10 為基準，技能基礎倍率從 4300% 增加至 9950% 。
14. 天帝 → 加油（跆拳少年少女）
：以 Lv5 為基準，傷害增加效果從 85% 增加至 100% 。
→ 日/月/星的憤怒（拳聖）
：追加傷害增加的上限值為(習得等級×25)% 。(未实装)
→ 天地滿星
：以 Lv5 為基準，技能基礎倍率從 2200% 增加至 2800%。
：天地滿星持續時間從 4.5 秒減少至 3.5 秒。
：流星攻擊間隔時間從 0.3 秒增加至 0.5 秒。
：SP 消耗量從 84 增加至 124。
→ 天星
：技能獨立延遲從 5 秒減少至 3.5 秒。
：以 Lv5 為基準，技能基礎倍率從 2700% 增加至 3000%。
：天星持續時間從 4.5 秒減少至 2.5 秒，流星攻擊間隔時間從 0.3 秒增加至 0.5 秒。
：以 Lv5 為基準，流星降落數量從 4 顆減少至 2 顆。（未实装）
：流星的攻擊範圍從 7×7 減少至 5×5 。
：以 Lv5 為基準，SP 消耗量從 63 增加至 110。
→ 天羅萬象
：AP 消耗量從 35 增加至 70。
：以 Lv10 為基準，技能基礎倍率從 23000% 降低至 12250%。
15. 靈導士 → 青龍符
：技能射程距離從 9 格增加至 11 格。
：以 Lv5 為基準，技能基礎倍率從 7500%／8600% 增加至 9100%／11600% 。
→ 白虎符
：以 Lv5 為基準，SP 消耗量從 92 增加至 118。
：以 Lv5 為基準，技能基礎倍率從 5100%／7100% 增加至 5400%／7400%。
→ 朱雀符
：以 Lv5 為基準，技能基礎倍率從 5500%／7700% 增加至 7450%／9650% 。
→ 玄武符
：以 Lv5 為基準，技能基礎倍率從 9400%／11550% 增加至 10150%／12800%。 → 四方五行陣
：AP 消耗量從 25 增加至 35。
：四方五行陣狀態下變更為不會被魔法效果解除和解除消除效果。
16. 頂尖初心者 → 雙重怪物互擊
：擊退距離從 2 格減少至 1 格。
：以 Lv10 為基準，每 1 次基礎倍率從 2650% 增加至 3200%。
→ 高倍音速投擲
：技能獨立延遲從 0.3 秒增加至 0.35 秒。
：以 Lv10 為基準，技能基礎倍率從 5350% 增加至 8400%。
→ 連續盾擊衝刺
：技能獨立延遲從 0.3 秒增加至 0.35 秒。
：以 Lv10 為基準，技能基礎倍率從 5100% 增加至 5700%。
→ 最大螺旋擊刺
：技能獨立延遲從 0.3 秒增加至 0.35 秒。
：以 Lv10 為基準，技能基礎倍率從 4050% 增加至 8700%。
→ 地獄震動
：以 Lv10 為基準，SP 消耗量從 98 增加至 115。
→ 重力場域
：以 Lv10 為基準，SP 消耗量從 100 增加至 120。
→ 限界突破
：高倍音速投擲、最大螺旋擊刺傷害增長倍率從 70% 增加至 100%。
：雙重怪物互擊、連續盾擊衝刺傷害增長倍率從 50% 增加至 70%。
17. 靈魂師 → 鐵虎虛空爪
：技能射程距離從 9 格增加至 11 格。
：以 Lv7 為基準，技能基礎倍率從 5650%／6450% 增加至 12400%／15200%。（无改动） → 鐵虎咆哮
：SP 消耗量從 68 增加至 72。
→ 虎號哭亂打
：以 Lv7 為基準，SP 消耗量從 72 增加至 85。
→ 龜始 強烈震盪
：AP 恢復量從 3／6 減少至 2／4。
→ 玄鹿 綠葉新風
：以 Lv7 為基準，每 1 次基礎倍率從 4800%／6300% 增加至 5900%／7400%。（无改动） → 玄鹿砲
：技能射程距離從 9 格增加至 11 格。
：以 Lv7 為基準，SP 從 74 減少至 65 。
：以 Lv7 為基準，技能基礎倍率從 7350%／8500% 增加至 11900%／14000%。

<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
